### PR TITLE
share: publish a running tmux session as a URL

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,6 +22,10 @@ jobs:
         with:
           go-version: '1.25'
 
+      - name: Install tmux
+        if: runner.os == 'Linux'
+        run: sudo apt-get update && sudo apt-get install -y tmux
+
       # ./... rather than ./internal/... -- the latter silently skipped
       # every test under cmd/bitbang (arg reordering, serve-mode routing,
       # the known-hosts device table, remote-spec parsing), which is the

--- a/README.md
+++ b/README.md
@@ -348,10 +348,9 @@ Windows 10 version 1809 or Windows Server 2019 or later.
 
 ## Roadmap
 
-Shipping today: **shell, files, and proxy**, reachable from the browser or the CLI, plus scp-style file copy, **ad-hoc pairing** with a saved device table, and **terminal sharing** (`bitbang share`). Designed and on the way:
+Shipping today: **shell, files, and proxy**, reachable from the browser or the CLI, plus **TCP port forwarding**, scp-style file copy, **ad-hoc pairing** with a saved device table, and **terminal sharing** (`bitbang share`). Designed and on the way:
 
 - **Serial bridging** -- drive a remote `/dev/ttyUSB0` from a local virtual port (e.g. run Arduino IDE over the internet). An issue has been opened [here](https://github.com/richlegrand/bitbang-cli/issues/3).
-- **TCP port forwarding** -- `-L 5432:db.internal:5432` to reach LAN-only services. An issue has been opened [here](https://github.com/richlegrand/bitbang-cli/issues/4).
 - **Remote desktop** -- screen over a WebRTC video track, keyboard/mouse over the data channel.
 
 ## License

--- a/README.md
+++ b/README.md
@@ -60,6 +60,50 @@ bitbang serve proxy localhost:8080   # ...or pin a single target
 
 Each prints a QR code, URL and a pairing code.
 
+### Sharing a running session: `bitbang share`
+
+`serve shell` starts a new shell. `share` publishes a tmux session that is
+already running:
+
+```
+bitbang share                    # publish the current tmux session
+bitbang share --read-only        # publish without a control URL
+bitbang share status|stop|rotate
+```
+
+The command returns after publishing, so `Ctrl-Z`, `bitbang share`, `fg`
+works for a task already in progress. Hosting requires tmux 3.2+ on Unix or
+WSL. Native Windows clients can open the URLs but cannot host a share.
+
+By default, the command prints two bearer URLs:
+
+- The **Control URL** can type with the same authority as the local keyboard.
+  One controller may connect at a time.
+- The **View URL** is watch-only. Input is dropped before it reaches tmux, and
+  up to `--max-viewers` viewers may connect at once (default 16).
+
+`--read-only` omits the control credential entirely. Viewer and controller
+limits are held for each connection's lifetime, even before it opens a shell.
+
+Shares expire after `--ttl` (default `1h`); `--ttl 0` runs until stopped.
+Share URLs are ephemeral and are never saved to `devices.json`. `share stop`,
+TTL expiry, or removal of the source session disconnects remote peers without
+stopping the source session.
+
+Re-running `bitbang share` reprints the running share's URLs. If you
+pass a flag that disagrees with what is running (say `--read-only`
+against a share that has a control URL), it says so rather than
+handing back the old URLs; `bitbang share rotate` replaces the share
+with one that uses the new flags.
+
+A background worker runs in a detached `_bbshare_*` tmux management session,
+so there is no daemon or PID file to manage.
+
+Sharing changes no tmux options. With tmux's default `window-size latest`, the
+window follows the active read-write client; a lone viewer still supplies the
+only available size. If `window-size` has been overridden, `share` reports it
+but does not change the user's configuration.
+
 ### Connecting from a browser
 
 Open the URL. Depending on what's served, you get:
@@ -157,6 +201,8 @@ bitbang serve [flags]                  All capabilities: shell + files + proxy o
 bitbang serve shell [flags]            Shell only
 bitbang serve files [PATH] [flags]     Files only (PATH defaults to cwd)
 bitbang serve proxy [TARGET] [flags]   HTTP/WebSocket reverse proxy (TARGET pins one host:port)
+bitbang share [flags]                  Publish a running tmux session
+bitbang share status|stop|rotate       Inspect, stop, or replace a share
 bitbang connect <target> [-- cmd …]    Client shell (interactive or one-shot)
 bitbang cp <src> <dst>                 Copy files (one side is <URL>:/path, or '-')
 bitbang version                        Print version (also --version)
@@ -193,6 +239,21 @@ bitbang help                           Usage (also --help, -h)
 | `serve files [PATH]`       | positional `PATH` (default cwd) | `-upload`       |
 
 *(Advanced: `-video-fd N` passes an inherited socketpair FD to an external video helper; for internal/embedding use.)*
+
+### `bitbang share` -- publish a running tmux session
+
+| Flag               | Default           | Description                                                  |
+| ------------------ | ----------------- | ------------------------------------------------------------ |
+| `-read-only`       | off               | Do not generate a control credential                         |
+| `-ttl DURATION`    | `1h`              | Lifetime up to `8760h`; `0` means until stopped              |
+| `-target SESSION`  | enclosing session | Session name or `$id`; required when run outside tmux        |
+| `-socket PATH`     | enclosing server  | tmux socket; needed for a non-default server outside tmux    |
+| `-max-viewers N`   | `16`              | Maximum concurrent view-only peers                           |
+| `-server HOST`     | `bitba.ng`        | Signaling server hostname                                    |
+| `-v`               | off               | Verbose logging                                              |
+
+`share status`, `share stop`, and `share rotate` accept the same target and
+socket flags. `rotate` also accepts publication flags and issues fresh URLs.
 
 ### `bitbang connect <target> [-- command …]` -- client shell
 
@@ -275,11 +336,10 @@ Windows 10 version 1809 or Windows Server 2019 or later.
 
 ## Roadmap
 
-Shipping today: **shell, files, and proxy**, reachable from the browser or the CLI, plus scp-style file copy and **ad-hoc pairing** with a saved device table. Designed and on the way:
+Shipping today: **shell, files, and proxy**, reachable from the browser or the CLI, plus scp-style file copy, **ad-hoc pairing** with a saved device table, and **terminal sharing** (`bitbang share`). Designed and on the way:
 
 - **Serial bridging** -- drive a remote `/dev/ttyUSB0` from a local virtual port (e.g. run Arduino IDE over the internet). An issue has been opened [here](https://github.com/richlegrand/bitbang-cli/issues/3).
 - **TCP port forwarding** -- `-L 5432:db.internal:5432` to reach LAN-only services. An issue has been opened [here](https://github.com/richlegrand/bitbang-cli/issues/4).
-- **Terminal sharing** -- turn a *running* terminal session into a URL -- walk away mid-task and reopen it on your phone, or hand the link to someone else, perhaps useful for AI coding sessions. An issue has been opened [here](https://github.com/richlegrand/bitbang-cli/issues/5).
 - **Remote desktop** -- screen over a WebRTC video track, keyboard/mouse over the data channel.
 
 ## License
@@ -289,4 +349,3 @@ MIT -- see [LICENSE](LICENSE).
 ## Contributing
 
 Issues and PRs welcome.
-

--- a/cmd/bitbang/connect.go
+++ b/cmd/bitbang/connect.go
@@ -14,6 +14,8 @@ import (
 	"golang.org/x/term"
 
 	"github.com/richlegrand/bitbang/internal/client"
+	"github.com/richlegrand/bitbang/internal/protocol"
+	"github.com/richlegrand/bitbang/internal/signaling"
 )
 
 // runConnect implements `bitbang connect <name-or-URL-or-pair-code> [-- argv...]`.
@@ -28,9 +30,11 @@ import (
 //     then continues into the same direct connect using the obtained creds.
 //   - Anything else → URL flow. Opens a remote shell to the listener.
 //
-// Every successful connection is recorded in the table (see recordDevice).
-// Pass -name to choose the stored name; without it an auto name (device<N>)
-// is assigned and printed.
+// Successful connections are recorded in the table (see recordDevice),
+// except for URLs carrying the !ephemeral flag: a `bitbang share` link
+// dies with the share, so saving it would leave a device entry that
+// never works again. Pass -name to choose the stored name; without it
+// an auto name (device<N>) is assigned and printed.
 //
 // Mode auto-detection (URL flow only):
 //   - Interactive: stdin is a TTY and no argv is given. Allocate a PTY
@@ -73,11 +77,18 @@ func runConnect(args []string) {
 		}
 	}
 
+	// Parse the URL shape first, because whether -name means anything
+	// depends on it: an ephemeral share URL is never saved, so its name
+	// is ignored either way and a name clash is not worth failing over.
+	urlSpec, isURL := parseConnectURL(urlArg)
+	isURL = isURL && !looksLikeDeviceName(urlArg) && !pairCodePattern.MatchString(urlArg)
+	ephemeralURL := isURL && urlSpec.Ephemeral
+
 	// Validate -name up front so a bad or already-taken name fails fast,
 	// before any pairing or dialing. The authoritative checks live in
 	// recordDevice (it knows the UID), but catching the common mistakes here
 	// spares the operator a pointless handshake.
-	if *name != "" {
+	if *name != "" && !ephemeralURL {
 		if err := validateDeviceName(*name); err != nil {
 			fail("connect: %v", err)
 		}
@@ -120,7 +131,7 @@ func runConnect(args []string) {
 		saved = true
 	default:
 		var ok bool
-		rs, ok = parseConnectURL(urlArg)
+		rs, ok = urlSpec, isURL
 		if !ok {
 			fail("connect: %q is not a saved device name, a 6-digit pair code, or a valid URL", urlArg)
 		}
@@ -138,9 +149,17 @@ func runConnect(args []string) {
 	fmt.Fprintln(os.Stderr, "Connected.")
 
 	// URL-flow hosts are remembered once we've actually connected. Pair and
-	// name-resolved hosts are already saved (see above).
+	// name-resolved hosts are already saved (see above). !ephemeral URLs
+	// (bitbang share) carry credentials that die with the share; never
+	// saved.
 	if !saved {
-		recordAndReport(rs, *name)
+		if rs.Ephemeral {
+			if *name != "" {
+				fmt.Fprintln(os.Stderr, "Not saving: this is an ephemeral share URL (-name ignored).")
+			}
+		} else {
+			recordAndReport(rs, *name)
+		}
 	}
 
 	opts := client.ShellOptions{
@@ -157,9 +176,15 @@ func runConnect(args []string) {
 	// os.Exit, which skips defers — so we call restore explicitly
 	// before each os.Exit (sync.Once inside makes double-calls safe).
 	restore := func() {}
-	if interactive {
+	switch {
+	case sess.ServerAccess == protocol.AccessView:
+		// A share's view URL: output only. No raw mode; the local
+		// terminal keeps cooked semantics, so Ctrl-C disconnects
+		// instead of becoming an input byte nobody transmits.
+		setupViewOnly(&opts)
+	case interactive:
 		restore = setupInteractive(&opts)
-	} else {
+	default:
 		setupNonInteractive(&opts)
 	}
 
@@ -240,6 +265,38 @@ func setupInteractive(opts *client.ShellOptions) func() {
 	return restore
 }
 
+// setupViewOnly configures a watch-only session (a bitbang share view
+// URL, where the listener granted access="view"). Nothing is
+// transmitted but the terminal size: stdin is dropped and no signals
+// are forwarded, matching what the listener would enforce anyway.
+// Resizes still go out because they only size this viewer's own PTY on
+// the far side. Without them the remote grid would not match the local
+// window and the rendering would wrap wrongly.
+func setupViewOnly(opts *client.ShellOptions) {
+	opts.Stdin = nil
+	opts.PTY = true
+	fmt.Fprintln(os.Stderr, "View-only session: watching, input is not transmitted. Ctrl-C to disconnect.")
+
+	if cols, rows, err := term.GetSize(int(os.Stdout.Fd())); err == nil {
+		opts.Cols = cols
+		opts.Rows = rows
+	}
+	resizes := make(chan client.ShellSize, 4)
+	winch := make(chan os.Signal, 4)
+	notifyWindowChanges(winch)
+	go func() {
+		for range winch {
+			if cols, rows, err := term.GetSize(int(os.Stdout.Fd())); err == nil {
+				select {
+				case resizes <- client.ShellSize{Cols: cols, Rows: rows}:
+				default:
+				}
+			}
+		}
+	}()
+	opts.Resizes = resizes
+}
+
 // setupNonInteractive wires Ctrl-C / SIGTERM / SIGHUP to the explicit
 // signal-forwarding channel. The local terminal stays in cooked mode;
 // pipes flow through unmodified.
@@ -314,8 +371,8 @@ func dialConnect(r remoteSpec, verbose bool, timeout time.Duration, suppliedPIN 
 // path is meaningless — a shell stream doesn't address a path.
 //
 // Fragment grammar (see CONVENTIONS.md): `<code>[!<flags>][/<device-URL>]`.
-// For `bitbang connect` the flags and device-URL are irrelevant — we take
-// only the code, stopping at the first `!` or `/`.
+// The device-URL part is irrelevant for connect; of the flags,
+// "ephemeral" (bitbang share URLs) suppresses the devices.json save.
 func parseConnectURL(arg string) (remoteSpec, bool) {
 	urlPart := arg
 	if !strings.Contains(urlPart, "://") {
@@ -336,13 +393,11 @@ func parseConnectURL(arg string) (remoteSpec, bool) {
 	if uid == "" {
 		return remoteSpec{}, false
 	}
-	code := u.Fragment
-	if i := strings.IndexAny(code, "!/"); i >= 0 {
-		code = code[:i]
-	}
+	code, flags := signaling.ParseFragment(u.Fragment)
 	return remoteSpec{
-		Server: u.Host,
-		UID:    uid,
-		Code:   code,
+		Server:    u.Host,
+		UID:       uid,
+		Code:      code,
+		Ephemeral: signaling.HasFlag(flags, "ephemeral"),
 	}, true
 }

--- a/cmd/bitbang/cp.go
+++ b/cmd/bitbang/cp.go
@@ -13,6 +13,7 @@ import (
 	"golang.org/x/term"
 
 	"github.com/richlegrand/bitbang/internal/client"
+	"github.com/richlegrand/bitbang/internal/signaling"
 )
 
 // runCp implements `bitbang cp <src> <dst>`.
@@ -210,6 +211,9 @@ type remoteSpec struct {
 	UID    string
 	Code   string // access code, may be empty
 	Path   string // path on the remote, leading "/"
+
+	// Ephemeral suppresses device persistence for a share URL.
+	Ephemeral bool
 }
 
 // parseRemoteSpec returns (spec, true) if arg looks like a remote
@@ -260,17 +264,14 @@ func parseRemoteSpec(arg string) (remoteSpec, bool) {
 		return remoteSpec{}, false
 	}
 	// Fragment grammar (see CONVENTIONS.md): `<code>[!<flags>][/<device-URL>]`.
-	// For cp the device-URL is superseded by the `:/path` after the URL,
-	// and flags are irrelevant — take only the code.
-	code := u.Fragment
-	if i := strings.IndexAny(code, "!/"); i >= 0 {
-		code = code[:i]
-	}
+	// For cp the device URL is superseded by the `:/path` after the URL.
+	code, flags := signaling.ParseFragment(u.Fragment)
 	return remoteSpec{
-		Server: u.Host,
-		UID:    uid,
-		Code:   code,
-		Path:   rest,
+		Server:    u.Host,
+		UID:       uid,
+		Code:      code,
+		Path:      rest,
+		Ephemeral: signaling.HasFlag(flags, "ephemeral"),
 	}, true
 }
 

--- a/cmd/bitbang/main.go
+++ b/cmd/bitbang/main.go
@@ -1,5 +1,6 @@
-// Command bitbang is the BitBang CLI: a single binary with a listener
-// entrypoint (`serve`) and two client subcommands (`cp`, `connect`).
+// Command bitbang is the BitBang CLI. It can serve a shell, files, and
+// HTTP endpoints; connect to another listener; copy files; or publish a
+// running tmux session.
 //
 // Usage:
 //
@@ -7,6 +8,8 @@
 //	bitbang serve shell [flags]                   # shell only
 //	bitbang serve files [PATH] [flags]            # files only, PATH defaults to cwd
 //	bitbang serve proxy [flags]                   # proxy only (HTTP reverse proxy)
+//	bitbang share [flags]                         # publish the current tmux session
+//	bitbang share status|stop|rotate              # manage a running share
 //	bitbang cp <src> <dst>                        (one side is <URL>:/path, or `-`)
 //	bitbang connect <URL> [-- argv]               (client: interactive or one-shot)
 //
@@ -44,6 +47,8 @@ func main() {
 	switch os.Args[1] {
 	case "serve":
 		dispatchServe(os.Args[2:])
+	case "share":
+		dispatchShare(os.Args[2:])
 	case "cp":
 		runCp(os.Args[2:])
 	case "connect":
@@ -90,8 +95,10 @@ func printUsage() {
 	fmt.Println("  bitbang serve shell [flags]            Shell only")
 	fmt.Println("  bitbang serve files [PATH] [flags]     Files only (PATH defaults to cwd)")
 	fmt.Println("  bitbang serve proxy [flags]            Proxy only (HTTP reverse proxy)")
+	fmt.Println("  bitbang share [flags]                  Publish the current tmux session as a URL")
+	fmt.Println("  bitbang share status|stop|rotate       Manage a running share")
 	fmt.Println("  bitbang cp <src> <dst>                 Copy files (one side is <URL>:/path, or '-')")
 	fmt.Println("  bitbang connect <URL-or-code> [-- ...]  Open shell, or pair via 6-digit code")
 	fmt.Println()
-	fmt.Println("Run `bitbang serve --help` (or with a mode) for the available flags.")
+	fmt.Println("Run a command with `--help` for its available flags.")
 }

--- a/cmd/bitbang/readiness.go
+++ b/cmd/bitbang/readiness.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"sync/atomic"
+	"time"
+)
+
+// unreadyPeerTimeout allows time for an interactive PIN prompt while bounding
+// peers that request a connection and never answer.
+const unreadyPeerTimeout = 2 * time.Minute
+
+type deadlineGuard struct {
+	done  atomic.Bool
+	timer *time.Timer
+}
+
+// newDeadlineGuard runs expire unless Done wins the race first.
+func newDeadlineGuard(after time.Duration, expire func()) *deadlineGuard {
+	g := &deadlineGuard{}
+	g.timer = time.AfterFunc(after, func() {
+		if g.done.CompareAndSwap(false, true) {
+			expire()
+		}
+	})
+	return g
+}
+
+func (g *deadlineGuard) Done() {
+	if g != nil && g.done.CompareAndSwap(false, true) {
+		g.timer.Stop()
+	}
+}

--- a/cmd/bitbang/readiness_test.go
+++ b/cmd/bitbang/readiness_test.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"testing"
+	"time"
+)
+
+func TestDeadlineGuard(t *testing.T) {
+	dropped := make(chan struct{})
+	newDeadlineGuard(20*time.Millisecond, func() { close(dropped) })
+	select {
+	case <-dropped:
+	case <-time.After(2 * time.Second):
+		t.Fatal("unready peer was not dropped")
+	}
+
+	stillThere := make(chan struct{})
+	guard := newDeadlineGuard(20*time.Millisecond, func() { close(stillThere) })
+	guard.Done()
+	select {
+	case <-stillThere:
+		t.Fatal("completed peer was dropped")
+	case <-time.After(100 * time.Millisecond):
+	}
+}

--- a/cmd/bitbang/serve.go
+++ b/cmd/bitbang/serve.go
@@ -464,6 +464,13 @@ func startListener(cfg serveConfig) {
 		switch msgType {
 		case "request":
 			clientID, _ := msg["client_id"].(string)
+			mu.Lock()
+			duplicate := connections[clientID] != nil
+			mu.Unlock()
+			if clientID == "" || duplicate {
+				log.Printf("Rejecting duplicate or empty client ID %q", clientID)
+				return
+			}
 			// Real browser IP from the signaling server (never client-set);
 			// stamped as X-Forwarded-For on proxied requests so the backend
 			// sees the true origin instead of our localhost socket peer.
@@ -546,15 +553,37 @@ func startListener(cfg serveConfig) {
 			unauthSessions.Add(1)
 			var releaseOnce sync.Once
 			release := func() { releaseOnce.Do(func() { unauthSessions.Add(-1) }) }
-			sess.OnReady = release
+
+			forget := func() {
+				mu.Lock()
+				if connections[clientID] == conn {
+					delete(connections, clientID)
+				}
+				mu.Unlock()
+			}
+
+			// Neither of the release paths above can be reached by a peer
+			// that requests a connection and then goes quiet: with no SDP
+			// answer the connection never leaves WebRTC's `new` state, so
+			// there is no data channel to close and no terminal state to
+			// observe. Without a deadline, maxUnauthSessions such peers
+			// wedge the listener for good.
+			deadline := newDeadlineGuard(unreadyPeerTimeout, func() {
+				log.Printf("Dropping %s: handshake not completed within %s", clientID, unreadyPeerTimeout)
+				conn.Close()
+			})
+			sess.OnReady = func() {
+				deadline.Done()
+				release()
+			}
 
 			// Per-connection teardown, run when the data channel closes.
 			var onClose []func()
-			onClose = append(onClose, release)
+			onClose = append(onClose, deadline.Done, release, forget)
 			// Kill any shell processes — without this they outlive the
 			// browser tab and keep holding their max-sessions slot.
 			if shellHandler != nil {
-				onClose = append(onClose, shellHandler.KillAll)
+				onClose = append(onClose, shellHandler.Close)
 			}
 			// Tear down the video PC and unregister the bridge.
 			if videoClient != nil {
@@ -572,17 +601,14 @@ func startListener(cfg serveConfig) {
 				sess.SetVideoBridge(bridge)
 				onClose = append(onClose, bridge.Close)
 			}
-			if len(onClose) > 0 {
-				conn.OnClose = func() {
-					for _, f := range onClose {
-						f()
-					}
-				}
-			}
-
 			mu.Lock()
 			connections[clientID] = conn
 			mu.Unlock()
+			conn.SetOnClose(func() {
+				for _, f := range onClose {
+					f()
+				}
+			})
 
 		case "answer":
 			clientID, _ := msg["client_id"].(string)
@@ -600,17 +626,26 @@ func startListener(cfg serveConfig) {
 			if conn.PairingMode {
 				if err := conn.HandlePairAnswer(sdp); err != nil {
 					log.Printf("Failed to handle pair answer: %v", err)
+					conn.Close()
 				}
 				return
 			}
 			encrypted, _ := msg["encrypted_request"].(string)
 			if err := conn.HandleAnswer(sdp, encrypted); err != nil {
 				log.Printf("Failed to handle answer: %v", err)
+				conn.Close()
 			}
 
 		case "pair_request":
 			clientID, _ := msg["client_id"].(string)
 			if clientID == "" {
+				return
+			}
+			mu.Lock()
+			duplicate := connections[clientID] != nil
+			mu.Unlock()
+			if duplicate {
+				log.Printf("Rejecting duplicate pair client ID %q", clientID)
 				return
 			}
 			conn, err := peer.HandlePairRequest(msg, signalingClient, id,
@@ -622,6 +657,18 @@ func startListener(cfg serveConfig) {
 			mu.Lock()
 			connections[clientID] = conn
 			mu.Unlock()
+			deadline := newDeadlineGuard(unreadyPeerTimeout, func() {
+				log.Printf("Dropping pair %s: handshake not completed within %s", clientID, unreadyPeerTimeout)
+				conn.Close()
+			})
+			conn.SetOnClose(func() {
+				deadline.Done()
+				mu.Lock()
+				if connections[clientID] == conn {
+					delete(connections, clientID)
+				}
+				mu.Unlock()
+			})
 
 		case "candidate":
 			clientID, _ := msg["client_id"].(string)

--- a/cmd/bitbang/share.go
+++ b/cmd/bitbang/share.go
@@ -1,0 +1,1108 @@
+package main
+
+// The share command publishes a running tmux session. A detached tmux
+// management session supervises the worker, so status and cleanup use tmux's
+// own liveness rather than PID files.
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"io/fs"
+	"log"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+
+	"golang.org/x/term"
+
+	"github.com/richlegrand/bitbang/internal/share"
+)
+
+// workerSubcommand is the hidden `bitbang share __worker` entry the
+// management session runs. Internal -- not listed in usage.
+const workerSubcommand = "__worker"
+
+// startTimeout bounds how long the foreground command waits for the
+// worker to register with signaling and publish its state file.
+const startTimeout = 15 * time.Second
+
+// stopGrace is how long a worker gets to exit after SIGTERM before the
+// stop escalates, and killGrace how long after SIGKILL. Variables so a
+// test can shrink them; nothing reassigns them in the binary.
+var (
+	stopGrace = 5 * time.Second
+	killGrace = 2 * time.Second
+)
+
+// sweepProbeTimeout bounds each old server probe. sweepBudget bounds the
+// complete best-effort sweep so stale sockets cannot delay every command.
+var (
+	sweepProbeTimeout = time.Second
+	sweepBudget       = 2 * time.Second
+)
+
+// sweepStep is a test hook for interleavings between sweep entries.
+var sweepStep = func() {}
+
+// killProcess is replaceable in tests so they never signal real PIDs.
+var killProcess = signalShareProcess
+
+type shareConfig struct {
+	readOnly   bool
+	ttl        string
+	target     string
+	socket     string
+	server     string
+	maxViewers int
+	verbose    bool
+
+	// ttlDuration is ttl parsed and validated at flag time, so a bad
+	// value fails before we touch tmux or a running share.
+	ttlDuration time.Duration
+
+	// set records explicitly supplied flags. A bare re-run prints the
+	// existing URLs; explicitly conflicting settings are rejected.
+	set map[string]bool
+}
+
+func registerShareFlags(fs *flag.FlagSet, cfg *shareConfig) {
+	fs.BoolVar(&cfg.readOnly, "read-only", false, "Viewers only -- no control credential is generated at all")
+	fs.StringVar(&cfg.ttl, "ttl", "1h", "Share lifetime (Go duration like 1h or 30m; 0 = until stopped)")
+	fs.StringVar(&cfg.target, "target", "", "tmux session to share (name or $id; default: the session you're in)")
+	fs.StringVar(&cfg.socket, "socket", "", "tmux server socket path (default: the enclosing server, or tmux's default)")
+	fs.StringVar(&cfg.server, "server", "bitba.ng", "Signaling server hostname")
+	fs.IntVar(&cfg.maxViewers, "max-viewers", 16, "Max concurrent view-only peers")
+	fs.BoolVar(&cfg.verbose, "v", false, "Verbose logging")
+}
+
+// dispatchShare routes `bitbang share [subcommand] [flags]`. Bare
+// `share` (or `share --flag`) starts/reprints a share; status, stop,
+// and rotate manage an existing one.
+func dispatchShare(args []string) {
+	if len(args) == 0 || args[0] == "" || args[0][0] == '-' {
+		runShare(args)
+		return
+	}
+	switch args[0] {
+	case "status":
+		runShareStatus(args[1:])
+	case "stop":
+		runShareStop(args[1:])
+	case "rotate":
+		runShareRotate(args[1:])
+	case workerSubcommand:
+		runShareWorker(args[1:])
+	default:
+		fmt.Fprintf(os.Stderr, "bitbang share: unknown subcommand %q (expected status, stop, or rotate)\n\n", args[0])
+		printUsage()
+		os.Exit(2)
+	}
+}
+
+func parseShareFlags(name string, args []string) shareConfig {
+	fs := flag.NewFlagSet(name, flag.ExitOnError)
+	var cfg shareConfig
+	registerShareFlags(fs, &cfg)
+	fs.Parse(reorderArgs(fs, args))
+	if fs.NArg() > 0 {
+		fmt.Fprintf(os.Stderr, "bitbang %s: unexpected argument %q\n", name, fs.Arg(0))
+		os.Exit(2)
+	}
+	cfg.set = make(map[string]bool)
+	fs.Visit(func(f *flag.Flag) { cfg.set[f.Name] = true })
+
+	ttl, err := parseTTL(cfg.ttl)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "bitbang %s: %v\n", name, err)
+		os.Exit(2)
+	}
+	cfg.ttlDuration = ttl
+	if cfg.maxViewers < 0 || cfg.maxViewers > share.MaxViewers {
+		fmt.Fprintf(os.Stderr, "bitbang %s: --max-viewers must be between 0 and %d\n", name, share.MaxViewers)
+		os.Exit(2)
+	}
+	return cfg
+}
+
+// maxTTL is the worker's own ceiling, restated here so --ttl is
+// rejected at the flag rather than inside the worker. See share.MaxTTL
+// for why there is a ceiling at all.
+const maxTTL = share.MaxTTL
+
+// parseTTL parses --ttl. "0" (or empty) means until stopped.
+//
+// Worker state stores whole seconds, so finer durations are rejected rather
+// than truncated. In particular, truncating a sub-second TTL to zero would
+// turn it into the "until stopped" sentinel.
+func parseTTL(s string) (time.Duration, error) {
+	if s == "" || s == "0" {
+		return 0, nil
+	}
+	d, err := time.ParseDuration(s)
+	if err != nil || d <= 0 {
+		return 0, fmt.Errorf("bad --ttl %q (want a Go duration like 1h or 30m, or 0 for until-stopped)", s)
+	}
+	if d < time.Second {
+		return 0, fmt.Errorf("--ttl %q is under a second; use at least 1s (or 0 to run until stopped)", s)
+	}
+	if d%time.Second != 0 {
+		return 0, fmt.Errorf("--ttl %q is not a whole number of seconds; %s would be silently rounded down",
+			s, d.Truncate(time.Second))
+	}
+	if d > maxTTL {
+		return 0, fmt.Errorf("--ttl %q is over the %s maximum; use 0 to run until stopped", s, maxTTL)
+	}
+	return d, nil
+}
+
+// shareTarget bundles everything resolved from the flags: the tmux
+// runner (bound to the right socket), the target session, and the
+// derived state-dir / management-session names.
+type shareTarget struct {
+	cfg    shareConfig
+	runner share.Runner
+	target share.Target
+	dir    string
+	lock   string
+	mgmt   string
+}
+
+func resolveShareTarget(cfg shareConfig) (*shareTarget, error) {
+	if !shareHostSupported {
+		return nil, errors.New("bitbang share requires tmux on Unix or WSL; native Windows can still open share URLs with bitbang connect")
+	}
+	if _, err := exec.LookPath("tmux"); err != nil {
+		return nil, fmt.Errorf("tmux not found in PATH -- `bitbang share` attaches to a running tmux session; start one with `tmux` first")
+	}
+	socket := cfg.socket
+	if socket == "" {
+		socket = share.SocketFromEnv()
+	}
+	runner := share.NewRunner(socket)
+	if err := share.CheckVersion(runner); err != nil {
+		return nil, err
+	}
+	tgt, err := share.Discover(runner, cfg.target)
+	if err != nil {
+		return nil, err
+	}
+	// Key on the server's own answer, not the spelling we reached it
+	// by, so `share status` from outside tmux finds the share that
+	// `share` started from inside it.
+	if tgt.Socket == "" {
+		tgt.Socket = socket
+	}
+	hash := share.TargetHash(tgt.Socket, tgt.SessionID)
+	dir, err := share.Dir(hash)
+	if err != nil {
+		return nil, err
+	}
+	lock, err := share.LockPath(hash)
+	if err != nil {
+		return nil, err
+	}
+	return &shareTarget{
+		cfg:    cfg,
+		runner: runner,
+		target: tgt,
+		dir:    dir,
+		lock:   lock,
+		mgmt:   "_bbshare_" + hash,
+	}, nil
+}
+
+// lockTarget takes the non-blocking per-target lifecycle lock. It spans
+// classification, cleanup, worker creation, and state acceptance so another
+// command cannot replace the share between a decision and its effect. Workers
+// do not hold it for the lifetime of a share.
+func lockTarget(st *shareTarget) *share.Lock {
+	if err := os.MkdirAll(filepath.Dir(st.lock), 0o700); err != nil {
+		fmt.Fprintf(os.Stderr, "Cannot create %s: %v\n", filepath.Dir(st.lock), err)
+		os.Exit(1)
+	}
+	lock, holder, err := share.TryLock(st.lock)
+	if err == nil {
+		return lock
+	}
+	if !errors.Is(err, share.ErrLockBusy) {
+		fmt.Fprintf(os.Stderr, "Cannot lock %s: %v\n", st.lock, err)
+		os.Exit(1)
+	}
+	fmt.Fprintf(os.Stderr, "Another `bitbang share` command is working on tmux session %q",
+		st.target.SessionName)
+	if holder > 0 {
+		fmt.Fprintf(os.Stderr, " (pid %d)", holder)
+	}
+	fmt.Fprintln(os.Stderr, ".\nWait for it to finish and try again.")
+	os.Exit(1)
+	return nil
+}
+
+// enterTarget begins a share command: take the target's lifecycle lock,
+// then collect what earlier shares left lying around.
+func enterTarget(st *shareTarget) *share.Lock {
+	lock := lockTarget(st)
+	sweepStranded(st.dir)
+	return lock
+}
+
+// sweepStranded removes the state directories of shares whose workers
+// are gone, skipping the one this command is here for.
+//
+// It exists because a worker cannot clean up after itself and the
+// ordinary stale path cannot always reach it. Every share command
+// resolves its target by asking tmux for a session ID -- so when the
+// *source* session is what disappeared, there is no lookup left that
+// arrives at its directory, and a new session of the same name hashes
+// somewhere else entirely. That directory would sit there with a dead
+// share's URLs in it forever. The same is true of anything left by a
+// worker that was killed outright, which is a case nothing else covers.
+//
+// Every removal is guarded the same way the targeted path is guarded.
+// Each directory is taken under its own lock, non-blocking, so a
+// directory another command is working on is simply left for next time;
+// nothing here needs to succeed on any particular run. State that
+// cannot be read is left alone, since it names no server to ask about.
+// A share is removed only when a successful tmux listing shows its worker
+// gone, or when the socket itself proves that no tmux server remains. Other
+// probe failures preserve the state.
+func sweepStranded(skip string) {
+	base, err := share.BaseDir()
+	if err != nil {
+		return
+	}
+	entries, err := os.ReadDir(base)
+	if err != nil {
+		return
+	}
+	deadline := time.Now().Add(sweepBudget)
+	warned := false
+	for _, entry := range entries {
+		if time.Now().After(deadline) {
+			// Nothing here has to finish on any given run, and the
+			// caller is waiting on a lock for work they did not ask for.
+			log.Printf("Stopped tidying old share state after %s; the rest will be looked at next time", sweepBudget)
+			return
+		}
+		name := entry.Name()
+		if !entry.IsDir() {
+			// A lock file whose target is gone. Taking it first is what
+			// keeps this from deleting the lock of a command that is
+			// between acquiring it and creating its directory.
+			if dir, ok := strings.CutSuffix(name, ".lock"); ok && dir != "" {
+				sweepOrphanLock(filepath.Join(base, dir))
+			}
+			continue
+		}
+		dir := filepath.Join(base, name)
+		if dir == skip {
+			continue
+		}
+		if socket := sweepOne(dir); socket != "" && !warned {
+			// Once per command. A share nothing can account for is kept,
+			// correctly -- but it is also paid for on every share command
+			// from here on, and the operator can only act on that if
+			// somebody says which one it is.
+			warned = true
+			log.Printf("An old share's tmux server at %s did not answer within %s; "+
+				"leaving %s alone. Remove that directory if the share is finished.",
+				socket, sweepProbeTimeout, dir)
+		}
+		sweepStep()
+	}
+}
+
+func sweepOrphanLock(dir string) {
+	lock, _, err := share.TryLock(share.LockPathFor(dir))
+	if err != nil {
+		return
+	}
+	defer lock.Release()
+	if _, err := os.Stat(dir); err == nil || !errors.Is(err, fs.ErrNotExist) {
+		return
+	}
+	_ = os.Remove(share.LockPathFor(dir))
+}
+
+// sweepOne collects one target's leavings, or leaves them where they
+// are. It returns the socket it could not get an answer out of, so the
+// caller can mention it once instead of once per directory.
+//
+// All evidence is collected after taking this target's lock. Reusing a
+// listing collected for another target would allow a share started during
+// the sweep to be mistaken for stale state.
+func sweepOne(dir string) string {
+	lock, _, err := share.TryLock(share.LockPathFor(dir))
+	if err != nil {
+		return "" // held by another command, or unusable -- either way, not now
+	}
+	defer lock.Release()
+
+	st, err := share.LoadState(dir)
+	if err != nil {
+		return "" // unreadable: it names no server, so there is nothing to ask
+	}
+	if st == nil {
+		// No state and no command working here: a directory whose share
+		// never got as far as publishing, or whose state is already gone.
+		removeStranded(dir)
+		return ""
+	}
+	if st.MgmtSession == "" {
+		return ""
+	}
+
+	// Bounded, because this is the one place a share command touches
+	// servers it has no business waiting on. An old socket path taken
+	// over by something that accepts connections and never speaks tmux
+	// would otherwise hang every share, status, stop and rotate on this
+	// machine.
+	runner := share.NewRunner(st.Socket)
+	runner.Timeout = sweepProbeTimeout
+
+	out, err := runner.Run("list-panes", "-a", "-F", paneListFormat)
+	if err != nil {
+		// No answer. The only thing that settles it from here is a
+		// socket with provably nothing behind it.
+		if serverIsGone(st.Socket) {
+			log.Printf("Removing stranded share state for tmux session %q at %s", st.SessionName, dir)
+			removeStranded(dir)
+			return ""
+		}
+		return st.Socket
+	}
+
+	switch state, _ := findPane(out, st.MgmtSession); state {
+	case mgmtRunning:
+		return ""
+	case mgmtDead:
+		// A husk kept listed by a global remain-on-exit. Its worker is
+		// gone, but the name is still taken, and nothing else will ever
+		// come back for it -- the targeted path needs a source session
+		// that no longer exists. Reap it exactly, and keep the state if
+		// that fails, so the next sweep tries again rather than leaving
+		// a name with no record of what holds it.
+		if _, err := runner.Run("kill-session", "-t", "="+st.MgmtSession); err != nil {
+			log.Printf("Could not remove the dead management session %s: %v", st.MgmtSession, err)
+			return ""
+		}
+	}
+	log.Printf("Removing stranded share state for tmux session %q at %s", st.SessionName, dir)
+	removeStranded(dir)
+	return ""
+}
+
+// serverIsGone reports whether a tmux server is definitively absent
+// from a socket. Asked only once tmux itself has failed to answer.
+//
+// A dead tmux server may leave its socket file behind, so this connects
+// rather than using stat. ECONNREFUSED and ENOENT prove there is no server;
+// permission and timeout errors do not.
+//
+// Bounded for the same reason the tmux call before it is: connect() on
+// a unix socket blocks while the listener's backlog is full.
+func serverIsGone(socket string) bool {
+	if socket == "" {
+		return false
+	}
+	conn, err := net.DialTimeout("unix", socket, sweepProbeTimeout)
+	if err == nil {
+		_ = conn.Close()
+		return false
+	}
+	return errors.Is(err, syscall.ECONNREFUSED) || errors.Is(err, fs.ErrNotExist)
+}
+
+// removeStranded drops a finished share's directory and lock file. The caller
+// holds that lock and has already established that no share remains.
+func removeStranded(dir string) {
+	if err := share.RemoveState(dir); err != nil {
+		log.Printf("Could not remove stranded share state at %s: %v", dir, err)
+		return
+	}
+	_ = os.Remove(share.LockPathFor(dir))
+}
+
+// tmux falls back to prefix matching for session names. "=name" forces an
+// exact session target; commands that require a window use "=name:".
+func (st *shareTarget) sessionTarget() string { return "=" + st.mgmt }
+func (st *shareTarget) windowTarget() string  { return "=" + st.mgmt + ":" }
+
+// mgmtState is what tmux can tell us about the management session.
+// "unknown" exists because a failed probe is not an answer: a fork
+// failure would otherwise read as "gone" and get a live share's state
+// deleted.
+type mgmtState int
+
+const (
+	mgmtGone    mgmtState = iota // tmux answered: no such session
+	mgmtDead                     // tmux answered: session listed, its pane has exited
+	mgmtRunning                  // tmux answered: session exists with a live pane
+	mgmtUnknown                  // tmux could not be asked
+)
+
+// exited reports that the worker process is definitively not running.
+// tmux spawned the pane's process and reaps it, so both a session that
+// has gone and one left listed with a dead pane are proof of that; they
+// differ only in whether a husk is left to clear away.
+func (m mgmtState) exited() bool { return m == mgmtGone || m == mgmtDead }
+
+// probeMgmtPane reports the management session's state and, when one is
+// running, the PID of its pane.
+//
+// The target-independent list-panes call returns liveness and PID from one
+// snapshot. A successful listing that omits the exact session name proves it
+// is gone; a failed listing proves nothing. Dead panes and PIDs at or below 1
+// are never signaled.
+func probeMgmtPane(st *shareTarget) (mgmtState, int) {
+	out, err := st.runner.Run("list-panes", "-a", "-F", paneListFormat)
+	if err != nil {
+		return mgmtUnknown, 0
+	}
+	return findPane(out, st.mgmt)
+}
+
+// paneListFormat is the one snapshot every liveness question is
+// answered from, so the targeted probe and the sweep cannot come to
+// different conclusions about the same pane.
+const paneListFormat = "#{session_name}\t#{pane_dead}\t#{pane_pid}"
+
+// findPane locates a session in a paneListFormat listing. Absent from a
+// listing that worked means gone; a retained dead pane is not running.
+func findPane(listing, session string) (mgmtState, int) {
+	for _, line := range strings.Split(listing, "\n") {
+		fields := strings.Split(strings.TrimRight(line, "\r"), "\t")
+		if len(fields) < 3 || fields[0] != session {
+			continue
+		}
+		if fields[1] == "1" {
+			return mgmtDead, 0
+		}
+		pid, err := strconv.Atoi(strings.TrimSpace(fields[2]))
+		if err != nil || pid <= 1 {
+			return mgmtRunning, 0
+		}
+		return mgmtRunning, pid
+	}
+	return mgmtGone, 0
+}
+
+func probeMgmt(st *shareTarget) mgmtState {
+	state, _ := probeMgmtPane(st)
+	return state
+}
+
+// workerPID reports the management pane's process and whether tmux
+// vouched for it being alive in the same breath.
+func workerPID(st *shareTarget) (int, bool) {
+	state, pid := probeMgmtPane(st)
+	return pid, state == mgmtRunning && pid > 0
+}
+
+// shareLiveness is what a target's state directory and management
+// session say between them.
+type shareLiveness int
+
+const (
+	shareAbsent    shareLiveness = iota // nothing on disk, nothing running
+	shareLive                           // state readable, worker running
+	shareStale                          // state left by a worker that is gone
+	shareUnmanaged                      // worker running, state missing or corrupt
+)
+
+// loadLiveShare classifies the target from one list-panes snapshot and
+// the state file.
+//
+// The state file is never trusted alone. A worker whose state is
+// unreadable is still serving its URLs, so treating that as stale -- and
+// deleting the directory, as the callers do -- would strip the only
+// record of a live share and leave a management session nobody can
+// name. The same goes for state that has gone missing entirely, which
+// is what a parent killed mid-startup leaves behind.
+func loadLiveShare(st *shareTarget) (*share.State, shareLiveness) {
+	s, err := share.LoadState(st.dir)
+	switch probeMgmt(st) {
+	case mgmtUnknown:
+		// Never clean up on a guess. Callers treat this as live, which
+		// costs a confusing message; treating it as gone would cost a
+		// running share its state.
+		log.Printf("Could not ask tmux whether the share is running; assuming it is")
+		if err != nil || s == nil {
+			return nil, shareUnmanaged
+		}
+		return s, shareLive
+	case mgmtRunning:
+		if err != nil {
+			log.Printf("Share state is unreadable: %v", err)
+			return nil, shareUnmanaged
+		}
+		if s == nil {
+			return nil, shareUnmanaged
+		}
+		return s, shareLive
+	default: // gone, or listed with a dead pane -- either way, not running
+		if err != nil {
+			log.Printf("Share state is unreadable: %v", err)
+			return &share.State{}, shareStale
+		}
+		if s == nil {
+			return nil, shareAbsent
+		}
+		return s, shareStale
+	}
+}
+
+// reportUnmanaged explains a running share whose URLs cannot be recovered.
+func reportUnmanaged(st *shareTarget) {
+	fmt.Fprintf(os.Stderr, "A share is running for tmux session %q, but its state file is missing or unreadable.\n",
+		st.target.SessionName)
+	fmt.Fprintln(os.Stderr, "Its URLs cannot be recovered. Run `bitbang share rotate` to replace it with a new")
+	fmt.Fprintln(os.Stderr, "share, or `bitbang share stop` to end it.")
+	os.Exit(1)
+}
+
+func runShare(args []string) {
+	cfg := parseShareFlags("share", args)
+	st, err := resolveShareTarget(cfg)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	}
+	defer enterTarget(st).Release()
+	existing, liveness := loadLiveShare(st)
+	switch liveness {
+	case shareUnmanaged:
+		reportUnmanaged(st)
+	case shareStale:
+		if err := cleanupStale(st); err != nil {
+			fmt.Fprintf(os.Stderr, "%v\n", err)
+			os.Exit(1)
+		}
+	}
+	if liveness == shareLive {
+		// Re-running `share` reprints the live share's URLs. That is
+		// only honest while the request matches what is running: a
+		// share started read-write cannot answer `--read-only` by
+		// handing back its control URL.
+		if conflicts := shareConflicts(st.cfg, existing); len(conflicts) > 0 {
+			fmt.Fprintf(os.Stderr, "A share is already running for tmux session %q, with different settings:\n",
+				st.target.SessionName)
+			for _, c := range conflicts {
+				fmt.Fprintf(os.Stderr, "  - %s\n", c)
+			}
+			fmt.Fprintln(os.Stderr, "\nRun `bitbang share rotate` with those flags to replace it (issues new URLs),")
+			fmt.Fprintln(os.Stderr, "or `bitbang share stop` to end it first.")
+			os.Exit(1)
+		}
+		fmt.Printf("Share already running for session %q -- reusing it (run `bitbang share rotate` for fresh URLs).\n\n",
+			st.target.SessionName)
+		printShareURLs(existing)
+		return
+	}
+	startShare(st)
+}
+
+// shareConflicts lists the ways the explicitly-requested options differ
+// from the share already running for this target. Only flags the user
+// typed are compared, so `bitbang share` with no flags always reprints
+// and never argues with itself over a default.
+func shareConflicts(cfg shareConfig, s *share.State) []string {
+	var out []string
+	if cfg.set["read-only"] {
+		runningReadOnly := s.ControlURL == ""
+		if cfg.readOnly && !runningReadOnly {
+			out = append(out, "--read-only requested, but the running share has a control URL")
+		} else if !cfg.readOnly && runningReadOnly {
+			out = append(out, "control access requested, but the running share is view-only")
+		}
+	}
+	if cfg.set["ttl"] {
+		if want := int(cfg.ttlDuration / time.Second); want != s.TTLSeconds {
+			out = append(out, fmt.Sprintf("--ttl %s requested, running share uses %s",
+				describeTTL(want), describeTTL(s.TTLSeconds)))
+		}
+	}
+	if cfg.set["max-viewers"] && cfg.maxViewers != s.MaxViewers {
+		out = append(out, fmt.Sprintf("--max-viewers %d requested, running share allows %d",
+			cfg.maxViewers, s.MaxViewers))
+	}
+	if cfg.set["server"] && cfg.server != s.Server {
+		out = append(out, fmt.Sprintf("--server %s requested, running share uses %s", cfg.server, s.Server))
+	}
+	return out
+}
+
+func describeTTL(seconds int) string {
+	if seconds <= 0 {
+		return "no expiry"
+	}
+	return (time.Duration(seconds) * time.Second).String()
+}
+
+func runShareRotate(args []string) {
+	cfg := parseShareFlags("share rotate", args)
+	st, err := resolveShareTarget(cfg)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	}
+	defer enterTarget(st).Release()
+	switch _, liveness := loadLiveShare(st); liveness {
+	case shareLive, shareUnmanaged:
+		// stopWorker needs only the management session name, so a
+		// share with no usable state is still stoppable.
+		if !stopWorker(st) {
+			os.Exit(1)
+		}
+	case shareStale:
+		if err := cleanupStale(st); err != nil {
+			fmt.Fprintf(os.Stderr, "%v\n", err)
+			os.Exit(1)
+		}
+	}
+	startShare(st)
+}
+
+func runShareStatus(args []string) {
+	cfg := parseShareFlags("share status", args)
+	st, err := resolveShareTarget(cfg)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	}
+	defer enterTarget(st).Release()
+	existing, liveness := loadLiveShare(st)
+	switch liveness {
+	case shareUnmanaged:
+		reportUnmanaged(st)
+	case shareStale:
+		if err := cleanupStale(st); err != nil {
+			fmt.Fprintf(os.Stderr, "%v\n", err)
+			os.Exit(1)
+		}
+		fmt.Println("No active share (cleaned up stale state).")
+		os.Exit(1)
+	case shareAbsent:
+		fmt.Printf("No active share for session %q.\n", st.target.SessionName)
+		os.Exit(1)
+	}
+	fmt.Printf("Sharing tmux session %q (since %s)\n",
+		existing.SessionName, existing.CreatedAt.Local().Format("15:04:05"))
+	printShareURLs(existing)
+}
+
+func runShareStop(args []string) {
+	cfg := parseShareFlags("share stop", args)
+	st, err := resolveShareTarget(cfg)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	}
+	defer enterTarget(st).Release()
+	switch _, liveness := loadLiveShare(st); liveness {
+	case shareStale:
+		if err := cleanupStale(st); err != nil {
+			fmt.Fprintf(os.Stderr, "%v\n", err)
+			os.Exit(1)
+		}
+		fmt.Println("No active share (cleaned up stale state).")
+		return
+	case shareAbsent:
+		fmt.Printf("No active share for session %q.\n", st.target.SessionName)
+		return
+	}
+	if !stopWorker(st) {
+		os.Exit(1)
+	}
+	fmt.Println("Share stopped.")
+}
+
+// startShare spawns the detached worker and waits for it to come up.
+func startShare(st *shareTarget) {
+	ttl := st.cfg.ttlDuration
+	exe, err := os.Executable()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Cannot locate own binary: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Prepare the directory in the parent so permission and disk failures
+	// can be reported even if the worker cannot write its startup error.
+	if err := share.PrepareDir(st.dir); err != nil {
+		fmt.Fprintf(os.Stderr, "Cannot prepare the share state directory %s: %v\n", st.dir, err)
+		os.Exit(1)
+	}
+
+	// An operator running with remain-on-exit on globally leaves the
+	// husk of a dead worker's session holding the name this one needs.
+	if err := reapDeadMgmt(st, probeMgmt(st)); err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	}
+
+	nonce, err := share.NewNonce()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Cannot start share worker: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Clear anything a previous attempt left. The nonce already stops it
+	// being read as ours; this stops it accumulating.
+	share.TakeStartupError(st.dir, nonce)
+
+	workerArgv := []string{
+		exe, "share", workerSubcommand,
+		"-session", st.target.SessionID,
+		"-session-name", st.target.SessionName,
+		"-mgmt", st.mgmt,
+		"-statedir", st.dir,
+		"-server", st.cfg.server,
+		"-nonce", nonce,
+		"-ttl-seconds", strconv.Itoa(int(ttl / time.Second)),
+		"-max-viewers", strconv.Itoa(st.cfg.maxViewers),
+	}
+	if st.target.Socket != "" {
+		workerArgv = append(workerArgv, "-socket", st.target.Socket)
+	}
+	if st.cfg.readOnly {
+		workerArgv = append(workerArgv, "-read-only")
+	}
+	if st.cfg.verbose {
+		workerArgv = append(workerArgv, "-v")
+	}
+	quoted := make([]string, len(workerArgv))
+	for i, a := range workerArgv {
+		quoted[i] = share.ShellQuote(a)
+	}
+	// `exec` so the pane's #{pane_pid} IS the worker (tmux runs the
+	// command string through a shell) -- stop signals it directly.
+	cmdline := "exec " + strings.Join(quoted, " ")
+
+	if _, err := st.runner.Run("new-session", "-d", "-s", st.mgmt, cmdline); err != nil {
+		fmt.Fprintf(os.Stderr, "Cannot start share worker: %v\n", err)
+		if strings.Contains(err.Error(), "duplicate session") {
+			fmt.Fprintf(os.Stderr, "\nThe management session %s already exists, which means another\n", st.mgmt)
+			fmt.Fprintln(os.Stderr, "`bitbang share` is starting one for this same tmux session. Run")
+			fmt.Fprintln(os.Stderr, "`bitbang share status` once it has settled.")
+		}
+		os.Exit(1)
+	}
+
+	state, err := waitForState(st, nonce, startTimeout)
+	if err != nil {
+		// Read the diagnosis before stopping the worker: capture-pane
+		// needs the pane that stopWorker is about to take away. A
+		// worker that died recorded why on its way out, and its pane
+		// went with it, so the file is the only copy; a worker that is
+		// merely slow is still running, and its pane still holds the
+		// log saying what it is waiting on.
+		detail := share.TakeStartupError(st.dir, nonce)
+		if detail == "" {
+			out, captureErr := st.runner.Run("capture-pane", "-p", "-S", "-", "-t", st.windowTarget())
+			if captureErr != nil {
+				log.Printf("Could not read the worker's output: %v", captureErr)
+			}
+			detail = strings.TrimSpace(out)
+		}
+		fmt.Fprintf(os.Stderr, "Share failed to start: %v\n", err)
+		if detail != "" {
+			fmt.Fprintf(os.Stderr, "Worker output:\n  %s\n", strings.ReplaceAll(detail, "\n", "\n  "))
+		}
+		// Giving up on a worker is stopping a worker. Routing through
+		// the same path as `share stop` is what keeps a start that
+		// timed out on a live-but-slow worker from walking away and
+		// leaving it serving URLs nobody has a record of.
+		stopWorker(st)
+		os.Exit(1)
+	}
+
+	fmt.Printf("Sharing tmux session %q\n\n", st.target.SessionName)
+	printShareURLs(state)
+	printWindowSizeNote(st)
+}
+
+// printWindowSizeNote warns when the shared window won't resize to
+// whoever is currently driving it. tmux defaults `window-size` to
+// `latest`, which is what makes "reopen it on your phone" render at
+// phone size; an operator who has overridden it keeps their setting,
+// since a share changes no tmux options. See share.EffectiveWindowSize
+// for why the command does not write the option.
+func printWindowSizeNote(st *shareTarget) {
+	switch share.EffectiveWindowSize(st.runner, st.target.SessionID) {
+	case "latest", "":
+		// "" means the probe failed; don't invent advice from nothing.
+	case "manual":
+		fmt.Println("\nNote: this window's `window-size` is `manual`, so remote clients see it")
+		fmt.Println("      at its fixed size rather than their own.")
+	default:
+		fmt.Println("\nNote: this window's `window-size` is not `latest`, so it won't resize to")
+		fmt.Println("      whoever is currently driving it. `set -w window-size latest` to change that.")
+	}
+}
+
+// waitForState accepts state only when its nonce matches this start and tmux
+// still reports the worker running. An exited worker fails immediately; an
+// unavailable tmux server leaves the result unresolved until timeout.
+func waitForState(st *shareTarget, nonce string, timeout time.Duration) (*share.State, error) {
+	ticker := time.NewTicker(100 * time.Millisecond)
+	defer ticker.Stop()
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+	for {
+		s, _ := share.LoadState(st.dir)
+		ours := s != nil && s.Nonce == nonce && s.ViewURL != ""
+		state := probeMgmt(st)
+		switch {
+		case ours && state == mgmtRunning:
+			return s, nil
+		case state.exited():
+			// Either it never got as far as writing state, or it wrote
+			// and then died. Both are the same news.
+			return nil, errors.New("worker exited during startup")
+		}
+		select {
+		case <-ticker.C:
+		case <-timer.C:
+			return nil, fmt.Errorf("worker did not become ready within %s", timeout)
+		}
+	}
+}
+
+// stopWorker ends a running share and reports whether it is actually
+// gone.
+//
+// Order matters: the worker is confirmed dead BEFORE the management
+// session and state file are removed. Those two are the only handles
+// left for a second attempt, so tearing them down first would strand a
+// worker that is still serving its URLs with nothing to manage it by.
+//
+// "Confirmed" means tmux said so. A tmux that could not be asked is not
+// a confirmation and never authorises the cleanup -- it gets the same
+// treatment as a worker that refused to die: say so, change nothing,
+// leave the operator something to retry.
+func stopWorker(st *shareTarget) bool {
+	// Nothing signalled, nothing to wait for: the grace period exists to
+	// let a SIGTERM land, and waiting out five seconds for an effect we
+	// never caused would only delay an answer we already have.
+	pid, signalled := workerPID(st)
+	if signalled {
+		_ = killProcess(pid, syscall.SIGTERM)
+		if !waitForWorkerExit(st, stopGrace) {
+			// It ignored SIGTERM or is wedged. Escalate only against a
+			// pane tmux still vouches for, still running the number we
+			// signalled: once the worker exits the kernel may hand that
+			// number to anything, and five seconds is long enough for
+			// it to. Asking again narrows the window to the gap between
+			// the answer and the signal, which is as far as a PID can
+			// be trusted without pidfd or kqueue.
+			if again, ok := workerPID(st); ok && again == pid {
+				_ = killProcess(pid, syscall.SIGKILL)
+				waitForWorkerExit(st, killGrace)
+			}
+		}
+	}
+
+	switch state := probeMgmt(st); {
+	case state.exited():
+		// Confirmed gone -- now it is safe to drop the handles.
+		if err := cleanupStale(st); err != nil {
+			fmt.Fprintf(os.Stderr, "The worker exited, but %v\n", err)
+			return false
+		}
+		return true
+	case state == mgmtUnknown:
+		fmt.Fprintln(os.Stderr, "Could not stop the share: tmux did not answer, so there is no telling")
+		fmt.Fprintln(os.Stderr, "whether the worker exited. Nothing was removed -- retry `bitbang share stop`")
+		fmt.Fprintln(os.Stderr, "once tmux is reachable again.")
+		return false
+	default:
+		if pid > 0 {
+			fmt.Fprintf(os.Stderr, "Could not stop the share: worker process %d is still running.\n", pid)
+		} else {
+			fmt.Fprintln(os.Stderr, "Could not stop the share: its management session is still running.")
+		}
+		fmt.Fprintln(os.Stderr, "Its URLs stay answerable until it exits. The share is left in place")
+		fmt.Fprintln(os.Stderr, "so `bitbang share stop` can be retried.")
+		return false
+	}
+}
+
+// waitForWorkerExit polls until tmux reports the worker gone or the
+// budget runs out, reporting whether it exited.
+//
+// tmux's answer is the whole test. It spawned the pane's process and
+// reaps it, so a session that has gone -- or one left listed with a dead
+// pane -- is proof the process is not running. Adding a kill(pid, 0)
+// would only reintroduce the ambiguity tmux had just resolved: after
+// the number is reused it reports a live process that is not ours, and
+// waiting for it to stop being alive means waiting forever.
+func waitForWorkerExit(st *shareTarget, budget time.Duration) bool {
+	ticker := time.NewTicker(100 * time.Millisecond)
+	defer ticker.Stop()
+	timer := time.NewTimer(budget)
+	defer timer.Stop()
+	for {
+		if probeMgmt(st).exited() {
+			return true
+		}
+		select {
+		case <-ticker.C:
+		case <-timer.C:
+			return false
+		}
+	}
+}
+
+// cleanupStale drops what a dead worker left behind: its state
+// directory, and the husk of its management session when there is one.
+//
+// It asks tmux again rather than trusting the classification that sent
+// it here. Every caller does check first, so the guard is a backstop --
+// but this is the one function in the share path that deletes a
+// credential file, and the reason it exists is that "the caller already
+// checked" is exactly the assumption that goes stale.
+func cleanupStale(st *shareTarget) error {
+	state := probeMgmt(st)
+	if !state.exited() {
+		return fmt.Errorf("did not clean up %s: tmux no longer reports the worker as exited", st.dir)
+	}
+	if err := reapDeadMgmt(st, state); err != nil {
+		return err
+	}
+	if err := share.RemoveState(st.dir); err != nil {
+		return fmt.Errorf("could not remove stale share state at %s: %w", st.dir, err)
+	}
+	return nil
+}
+
+// reapDeadMgmt removes a management session tmux is keeping listed only
+// because the operator set remain-on-exit globally.
+//
+// There is nothing running in it -- that is what makes the pane dead --
+// but the session still holds its name, and `new-session -s` on a name
+// already taken fails with "duplicate session". Left alone, one dead
+// worker would block every future share of that target. The target is
+// anchored, so this can only ever reach our own session, and a pane
+// tmux reports as dead is a process tmux has already reaped.
+func reapDeadMgmt(st *shareTarget, state mgmtState) error {
+	if state != mgmtDead {
+		return nil
+	}
+	if _, err := st.runner.Run("kill-session", "-t", st.sessionTarget()); err != nil {
+		return fmt.Errorf("could not remove the dead management session %s, which still holds the name the next share needs: %w",
+			st.mgmt, err)
+	}
+	return nil
+}
+
+// humanUntil uses seconds for short TTLs and minutes for longer ones.
+func humanUntil(t time.Time) time.Duration {
+	d := time.Until(t)
+	if d < 0 {
+		return 0
+	}
+	if d < time.Minute {
+		return d.Round(time.Second)
+	}
+	return d.Round(time.Minute)
+}
+
+// printShareURLs renders the QR (control URL when one exists, view URL
+// otherwise) and the credential lines, mirroring serve's output style.
+func printShareURLs(s *share.State) {
+	bold, reset := "", ""
+	if term.IsTerminal(int(os.Stdout.Fd())) {
+		bold, reset = "\033[1m", "\033[0m"
+	}
+	qrURL := s.ControlURL
+	if qrURL == "" {
+		qrURL = s.ViewURL
+	}
+	fmt.Print(smallQR(qrURL))
+	if s.ControlURL != "" {
+		fmt.Printf("Control URL: %s%s%s\n", bold, s.ControlURL, reset)
+		fmt.Printf("             anyone with it can type -- same authority as your own keyboard\n")
+		fmt.Printf("View URL:    %s\n", s.ViewURL)
+		fmt.Printf("             watch only, up to %d viewers\n", s.MaxViewers)
+	} else {
+		fmt.Printf("View URL: %s%s%s\n", bold, s.ViewURL, reset)
+		fmt.Printf("          watch only (no control credential exists), up to %d viewers\n", s.MaxViewers)
+	}
+	if s.ExpiresAt.IsZero() {
+		fmt.Println("Expires:  when stopped (`bitbang share stop`)")
+	} else {
+		fmt.Printf("Expires:  %s (in %s) -- `bitbang share stop` to end early\n",
+			s.ExpiresAt.Local().Format("15:04"), humanUntil(s.ExpiresAt))
+	}
+}
+
+// runShareWorker is the hidden process hosted by the detached tmux
+// management session. The CLI owns flag parsing, signals, and exit codes;
+// internal/share owns the listener lifecycle.
+func runShareWorker(args []string) {
+	fs := flag.NewFlagSet("share "+workerSubcommand, flag.ExitOnError)
+	var (
+		sessionID   = fs.String("session", "", "target tmux session id")
+		sessionName = fs.String("session-name", "", "target session display name")
+		mgmt        = fs.String("mgmt", "", "management session name")
+		stateDir    = fs.String("statedir", "", "share state directory")
+		server      = fs.String("server", "bitba.ng", "signaling server")
+		nonce       = fs.String("nonce", "", "start-attempt nonce, recorded in the state file")
+		socket      = fs.String("socket", "", "tmux socket path")
+		ttlSeconds  = fs.Int("ttl-seconds", 0, "lifetime in seconds (0 = until stopped)")
+		maxViewers  = fs.Int("max-viewers", 16, "max concurrent viewers")
+		readOnly    = fs.Bool("read-only", false, "no control credential")
+		verbose     = fs.Bool("v", false, "verbose")
+	)
+	fs.Parse(args)
+	maxTTLSeconds := int(share.MaxTTL / time.Second)
+	// A missing nonce is worth failing on rather than starting a worker
+	// whose state the parent is guaranteed not to accept.
+	if *sessionID == "" || *mgmt == "" || *stateDir == "" || *nonce == "" ||
+		*ttlSeconds < 0 || *ttlSeconds > maxTTLSeconds ||
+		*maxViewers < 0 || *maxViewers > share.MaxViewers {
+		msg := fmt.Sprintf("share worker: invalid internal flags (ttl 0..%d, viewers 0..%d)",
+			maxTTLSeconds, share.MaxViewers)
+		fmt.Fprintln(os.Stderr, msg)
+		share.SaveStartupError(*stateDir, *nonce, msg)
+		os.Exit(2)
+	}
+
+	worker, err := share.NewWorker(share.WorkerConfig{
+		SessionID:   *sessionID,
+		SessionName: *sessionName,
+		MgmtSession: *mgmt,
+		StateDir:    *stateDir,
+		Server:      *server,
+		Socket:      *socket,
+		Nonce:       *nonce,
+		TTL:         time.Duration(*ttlSeconds) * time.Second,
+		MaxViewers:  *maxViewers,
+		ReadOnly:    *readOnly,
+		Verbose:     *verbose,
+	})
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		share.SaveStartupError(*stateDir, *nonce, err.Error())
+		os.Exit(1)
+	}
+
+	ctx, stop := shareWorkerContext()
+	defer stop()
+	if err := worker.Run(ctx); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		// The pane dies with this process, so leave the reason where
+		// the parent can still read it.
+		share.SaveStartupError(*stateDir, *nonce, err.Error())
+		if errors.Is(err, share.ErrPreempted) {
+			os.Exit(2)
+		}
+		os.Exit(1)
+	}
+}

--- a/cmd/bitbang/share_platform_other.go
+++ b/cmd/bitbang/share_platform_other.go
@@ -1,0 +1,24 @@
+//go:build !unix
+
+package main
+
+import (
+	"context"
+	"os"
+	"os/signal"
+	"syscall"
+)
+
+const shareHostSupported = false
+
+func signalShareProcess(pid int, sig syscall.Signal) error {
+	process, err := os.FindProcess(pid)
+	if err != nil {
+		return err
+	}
+	return process.Signal(sig)
+}
+
+func shareWorkerContext() (context.Context, context.CancelFunc) {
+	return signal.NotifyContext(context.Background(), os.Interrupt)
+}

--- a/cmd/bitbang/share_platform_other_test.go
+++ b/cmd/bitbang/share_platform_other_test.go
@@ -1,0 +1,18 @@
+//go:build !unix
+
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestShareHostingReportsUnsupportedPlatform(t *testing.T) {
+	if shareHostSupported {
+		t.Fatal("non-Unix build unexpectedly enables share hosting")
+	}
+	_, err := resolveShareTarget(shareConfig{})
+	if err == nil || !strings.Contains(err.Error(), "Unix or WSL") {
+		t.Fatalf("resolveShareTarget error = %v, want unsupported-platform guidance", err)
+	}
+}

--- a/cmd/bitbang/share_platform_unix.go
+++ b/cmd/bitbang/share_platform_unix.go
@@ -1,0 +1,19 @@
+//go:build unix
+
+package main
+
+import (
+	"context"
+	"os/signal"
+	"syscall"
+)
+
+const shareHostSupported = true
+
+func signalShareProcess(pid int, sig syscall.Signal) error {
+	return syscall.Kill(pid, sig)
+}
+
+func shareWorkerContext() (context.Context, context.CancelFunc) {
+	return signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGHUP, syscall.SIGINT)
+}

--- a/cmd/bitbang/share_test.go
+++ b/cmd/bitbang/share_test.go
@@ -1,0 +1,1301 @@
+//go:build unix
+
+package main
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/richlegrand/bitbang/internal/share"
+)
+
+func TestParseTTL(t *testing.T) {
+	tests := []struct {
+		in      string
+		want    time.Duration
+		wantErr bool
+	}{
+		{"1h", time.Hour, false},
+		{"30m", 30 * time.Minute, false},
+		{"90s", 90 * time.Second, false},
+		{"1s", time.Second, false},
+		{"0", 0, false},  // explicit "until stopped"
+		{"", 0, false},   // unset behaves like 0
+		{"-5m", 0, true}, // a share that expired before it started is a bug, not a feature
+		{"forever", 0, true},
+		{"10", 0, true}, // unitless is ambiguous -- reject rather than guess
+		// Sub-second values must be refused, not rounded: the worker
+		// takes whole seconds, so truncation would turn a short share
+		// into a permanent one -- the opposite of the request.
+		{"500ms", 0, true},
+		{"1ns", 0, true},
+		// Fractional values above a second are truncated by the same
+		// whole-seconds conversion, so 1500ms would quietly become 1s.
+		{"1500ms", 0, true},
+		{"90500ms", 0, true},
+		{"1.5s", 0, true},
+		// Absurdly long values are refused so the seconds count stays
+		// inside an int on 32-bit builds.
+		{"9000h", 0, true},
+		{"2000000h", 0, true},
+	}
+	for _, tc := range tests {
+		got, err := parseTTL(tc.in)
+		if tc.wantErr {
+			if err == nil {
+				t.Errorf("parseTTL(%q): got nil error, want rejection", tc.in)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("parseTTL(%q): %v", tc.in, err)
+			continue
+		}
+		if got != tc.want {
+			t.Errorf("parseTTL(%q) = %v, want %v", tc.in, got, tc.want)
+		}
+	}
+}
+
+// TestParseConnectURLEphemeral: a share URL must be recognized as
+// ephemeral so connect never writes it to devices.json, while ordinary
+// device URLs keep saving.
+func TestParseConnectURLEphemeral(t *testing.T) {
+	tests := []struct {
+		arg           string
+		wantCode      string
+		wantEphemeral bool
+	}{
+		{"https://bitba.ng/UID123#CODE456!ephemeral", "CODE456", true},
+		{"https://bitba.ng/UID123#CODE456", "CODE456", false},
+		{"bitba.ng/UID123#CODE456!ephemeral", "CODE456", true},
+		{"UID123#CODE456!ephemeral", "CODE456", true},
+		{"https://bitba.ng/UID123#CODE456!debug", "CODE456", false},
+		{"https://bitba.ng/UID123#CODE456!debug,ephemeral", "CODE456", true},
+		{"https://bitba.ng/UID123#CODE456!ephemeral,debug", "CODE456", true},
+	}
+	for _, tc := range tests {
+		rs, ok := parseConnectURL(tc.arg)
+		if !ok {
+			t.Errorf("parseConnectURL(%q): not parsed", tc.arg)
+			continue
+		}
+		if rs.Code != tc.wantCode {
+			t.Errorf("parseConnectURL(%q) code = %q, want %q", tc.arg, rs.Code, tc.wantCode)
+		}
+		if rs.Ephemeral != tc.wantEphemeral {
+			t.Errorf("parseConnectURL(%q) ephemeral = %v, want %v", tc.arg, rs.Ephemeral, tc.wantEphemeral)
+		}
+		if rs.UID != "UID123" {
+			t.Errorf("parseConnectURL(%q) uid = %q, want UID123", tc.arg, rs.UID)
+		}
+	}
+}
+
+func TestParseRemoteSpecEphemeral(t *testing.T) {
+	rs, ok := parseRemoteSpec("https://bitba.ng/UID123#CODE456!ephemeral:/tmp/file")
+	if !ok {
+		t.Fatal("parseRemoteSpec: not parsed")
+	}
+	if rs.Code != "CODE456" || !rs.Ephemeral || rs.Path != "/tmp/file" {
+		t.Errorf("got %+v, want code CODE456, ephemeral, path /tmp/file", rs)
+	}
+
+	rs, ok = parseRemoteSpec("https://bitba.ng/UID123#CODE456:/tmp/file")
+	if !ok {
+		t.Fatal("parseRemoteSpec (plain): not parsed")
+	}
+	if rs.Ephemeral {
+		t.Error("a plain device URL was marked ephemeral")
+	}
+}
+
+// TestParseTTLNeverSilentlyMeansForever is the property behind the
+// sub-second rejection: every accepted TTL must survive the conversion
+// to whole seconds that gets handed to the worker, where 0 is the
+// "until stopped" sentinel.
+func TestParseTTLNeverSilentlyMeansForever(t *testing.T) {
+	for _, in := range []string{"1s", "20s", "90s", "30m", "1h", "8h", "720h", "1h30m"} {
+		d, err := parseTTL(in)
+		if err != nil {
+			t.Errorf("parseTTL(%q): %v", in, err)
+			continue
+		}
+		secs := int(d / time.Second)
+		if secs <= 0 {
+			t.Errorf("parseTTL(%q) = %v, which becomes %d seconds -- the worker would read that as no expiry", in, d, secs)
+		}
+		// Whole-second conversion must be lossless, or the share would
+		// expire at a different time than the one requested.
+		if got := time.Duration(secs) * time.Second; got != d {
+			t.Errorf("parseTTL(%q) = %v but reaches the worker as %v", in, d, got)
+		}
+	}
+}
+
+func TestShareConflicts(t *testing.T) {
+	running := &share.State{
+		ControlURL: "https://bitba.ng/uid#ctrl!ephemeral",
+		ViewURL:    "https://bitba.ng/uid#view!ephemeral",
+		MaxViewers: 16,
+		Server:     "bitba.ng",
+		TTLSeconds: 3600,
+	}
+	readOnlyRunning := &share.State{
+		ViewURL:    "https://bitba.ng/uid#view!ephemeral",
+		MaxViewers: 16,
+		Server:     "bitba.ng",
+		TTLSeconds: 3600,
+	}
+
+	cfg := func(set map[string]bool, mutate func(*shareConfig)) shareConfig {
+		c := shareConfig{ttl: "1h", ttlDuration: time.Hour, maxViewers: 16, server: "bitba.ng", set: set}
+		if mutate != nil {
+			mutate(&c)
+		}
+		return c
+	}
+
+	tests := []struct {
+		name    string
+		cfg     shareConfig
+		state   *share.State
+		wantAny bool
+	}{
+		{"bare re-run reprints", cfg(map[string]bool{}, nil), running, false},
+		{"read-only against a control share", cfg(map[string]bool{"read-only": true},
+			func(c *shareConfig) { c.readOnly = true }), running, true},
+		{"read-only against a read-only share", cfg(map[string]bool{"read-only": true},
+			func(c *shareConfig) { c.readOnly = true }), readOnlyRunning, false},
+		{"control wanted from a read-only share", cfg(map[string]bool{"read-only": true},
+			func(c *shareConfig) { c.readOnly = false }), readOnlyRunning, true},
+		{"different ttl", cfg(map[string]bool{"ttl": true},
+			func(c *shareConfig) { c.ttl, c.ttlDuration = "30m", 30*time.Minute }), running, true},
+		{"same ttl restated", cfg(map[string]bool{"ttl": true}, nil), running, false},
+		{"different max-viewers", cfg(map[string]bool{"max-viewers": true},
+			func(c *shareConfig) { c.maxViewers = 2 }), running, true},
+		{"different server", cfg(map[string]bool{"server": true},
+			func(c *shareConfig) { c.server = "test.bitba.ng" }), running, true},
+		// A flag that was never typed must not be compared, or every
+		// default would argue with a share started using other flags.
+		{"untyped flags ignored", cfg(map[string]bool{},
+			func(c *shareConfig) { c.readOnly, c.maxViewers = true, 2 }), running, false},
+	}
+
+	for _, tc := range tests {
+		got := shareConflicts(tc.cfg, tc.state)
+		if (len(got) > 0) != tc.wantAny {
+			t.Errorf("%s: conflicts = %v, want any = %v", tc.name, got, tc.wantAny)
+		}
+	}
+}
+
+// fakeShareRunner answers tmux probes from a script, so the liveness
+// classification can be exercised without a tmux server.
+type fakeShareRunner struct {
+	sessionAlive bool
+	paneDead     bool
+	// probeErr, when set, is what a probe returns instead of an answer --
+	// a tmux that could not be run at all.
+	probeErr error
+	// serverUnreachable makes the target-independent probe fail too,
+	// which is how a live server behind an inaccessible socket looks:
+	// tmux exits non-zero for everything, and none of it is an answer.
+	serverUnreachable bool
+	// dieAfterProbes models a worker that exits once asked to stop:
+	// after this many liveness probes the session reports gone. Zero
+	// means it never exits on its own.
+	dieAfterProbes int
+	probes         int
+	calls          []string
+
+	// mgmt is the management session name the listing reports, matched
+	// locally by the classifier rather than by a tmux target.
+	mgmt string
+
+	// panePIDs are the successive answers to #{pane_pid}, the last one
+	// repeating -- a second, different value is how a test models the
+	// kernel reusing the number after the worker exits. The default
+	// answers 1, which the stop path refuses to signal, so a test never
+	// aims a signal at a real process by accident.
+	panePIDs []int
+	pidReads int
+}
+
+func (f *fakeShareRunner) Socket() string { return "" }
+
+func (f *fakeShareRunner) Run(args ...string) (string, error) {
+	f.calls = append(f.calls, strings.Join(args, " "))
+	switch args[0] {
+	case "list-panes":
+		// The classifier's one command: target-independent, so its
+		// success is the whole answer and its failure is no answer at
+		// all.
+		if f.probeErr != nil {
+			return "", f.probeErr
+		}
+		if f.serverUnreachable {
+			return "", errors.New("tmux list-panes: error connecting to /tmp/x (Permission denied)")
+		}
+		f.probes++
+		if f.dieAfterProbes > 0 && f.probes > f.dieAfterProbes {
+			f.sessionAlive = false
+		}
+		// Something unrelated is always listed, so "our session is
+		// absent" is distinguishable from "the listing was empty".
+		lines := []string{"someone-elses-session\t0\t999"}
+		if f.sessionAlive {
+			dead := "0"
+			if f.paneDead {
+				dead = "1"
+			}
+			pid := 1
+			if len(f.panePIDs) > 0 {
+				i := f.pidReads
+				if i >= len(f.panePIDs) {
+					i = len(f.panePIDs) - 1
+				}
+				pid = f.panePIDs[i]
+			}
+			f.pidReads++
+			lines = append(lines, f.mgmt+"\t"+dead+"\t"+strconv.Itoa(pid))
+		}
+		return strings.Join(lines, "\n"), nil
+	case "kill-session":
+		f.sessionAlive = false
+	}
+	return "", nil
+}
+
+// targetsUsed returns every -t argument the fake was asked for.
+func (f *fakeShareRunner) targetsUsed() []string {
+	var out []string
+	for _, c := range f.calls {
+		fields := strings.Fields(c)
+		for i, fld := range fields {
+			if fld == "-t" && i+1 < len(fields) {
+				out = append(out, fields[i+1])
+			}
+		}
+	}
+	return out
+}
+
+func newLivenessTarget(t *testing.T, alive bool) (*shareTarget, *fakeShareRunner) {
+	t.Helper()
+	r := &fakeShareRunner{sessionAlive: alive, mgmt: "_bbshare_test"}
+	base := t.TempDir()
+	return &shareTarget{
+		runner: r,
+		target: share.Target{SessionID: "$1", SessionName: "work"},
+		dir:    filepath.Join(base, "hash"),
+		lock:   filepath.Join(base, "hash.lock"),
+		mgmt:   "_bbshare_test",
+	}, r
+}
+
+// TestLoadLiveShareClassification is the guard against deleting a live
+// share's only record. State that cannot be read says nothing about
+// whether the worker is running, so tmux is always asked.
+func TestLoadLiveShareClassification(t *testing.T) {
+	good := &share.State{SessionID: "$1", ViewURL: "https://x/y#z", UID: "u"}
+
+	t.Run("readable state, worker running", func(t *testing.T) {
+		st, _ := newLivenessTarget(t, true)
+		if err := share.SaveState(st.dir, good); err != nil {
+			t.Fatal(err)
+		}
+		if s, l := loadLiveShare(st); l != shareLive || s == nil {
+			t.Errorf("got liveness %v, want shareLive with state", l)
+		}
+	})
+
+	t.Run("readable state, worker gone", func(t *testing.T) {
+		st, _ := newLivenessTarget(t, false)
+		if err := share.SaveState(st.dir, good); err != nil {
+			t.Fatal(err)
+		}
+		if _, l := loadLiveShare(st); l != shareStale {
+			t.Errorf("got liveness %v, want shareStale", l)
+		}
+	})
+
+	t.Run("corrupt state, worker running", func(t *testing.T) {
+		st, r := newLivenessTarget(t, true)
+		if err := os.MkdirAll(st.dir, 0o700); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(st.dir, "state.json"), []byte("{broken"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		_, l := loadLiveShare(st)
+		if l != shareUnmanaged {
+			t.Errorf("got liveness %v, want shareUnmanaged -- deleting here strips a live share's only record", l)
+		}
+		var probed bool
+		for _, c := range r.calls {
+			if strings.HasPrefix(c, "list-panes") {
+				probed = true
+			}
+		}
+		if !probed {
+			t.Error("tmux was never asked; unreadable state was assumed dead")
+		}
+	})
+
+	t.Run("corrupt state, worker gone", func(t *testing.T) {
+		st, _ := newLivenessTarget(t, false)
+		if err := os.MkdirAll(st.dir, 0o700); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(st.dir, "state.json"), []byte("{broken"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if _, l := loadLiveShare(st); l != shareStale {
+			t.Errorf("got liveness %v, want shareStale", l)
+		}
+	})
+
+	t.Run("no state, worker running (orphan)", func(t *testing.T) {
+		st, _ := newLivenessTarget(t, true)
+		if _, l := loadLiveShare(st); l != shareUnmanaged {
+			t.Errorf("got liveness %v, want shareUnmanaged for an orphaned management session", l)
+		}
+	})
+
+	t.Run("no state, nothing running", func(t *testing.T) {
+		st, _ := newLivenessTarget(t, false)
+		if _, l := loadLiveShare(st); l != shareAbsent {
+			t.Errorf("got liveness %v, want shareAbsent", l)
+		}
+	})
+}
+
+// tmux permits prefix matches for unanchored session targets. Commands that
+// name the management session must use exact targets.
+func TestMgmtTargetsAreExact(t *testing.T) {
+	st, r := newLivenessTarget(t, true)
+	r.paneDead = true // the husk path, which is what issues kill-session
+	loadLiveShare(st)
+	if err := cleanupStale(st); err != nil {
+		t.Fatalf("cleanupStale: %v", err)
+	}
+
+	if len(r.targetsUsed()) == 0 {
+		t.Fatal("expected at least one tmux target")
+	}
+	for _, tgt := range r.targetsUsed() {
+		if !strings.HasPrefix(tgt, "=") {
+			t.Errorf("target %q is not anchored; tmux would prefix-match it", tgt)
+		}
+	}
+}
+
+// remain-on-exit keeps a dead pane listed, but its PID must not be signaled.
+func TestDeadPaneIsNotLive(t *testing.T) {
+	st, r := newLivenessTarget(t, true)
+	r.paneDead = true
+
+	if got := probeMgmt(st); got != mgmtDead {
+		t.Errorf("probeMgmt = %v, want mgmtDead for a session whose pane has exited", got)
+	}
+	if err := share.SaveState(st.dir, &share.State{SessionID: "$1", ViewURL: "u", UID: "x"}); err != nil {
+		t.Fatal(err)
+	}
+	if _, l := loadLiveShare(st); l != shareStale {
+		t.Errorf("liveness = %v, want shareStale for a dead pane", l)
+	}
+
+	// And nothing may be signalled. The PID comes back in the same
+	// answer as the dead flag now, so the guarantee is not that we avoid
+	// asking -- it is that a dead pane yields no PID to send anything to.
+	sig := captureSignals(t)
+	r.panePIDs = []int{4242}
+	if !stopWorker(st) {
+		t.Fatal("stopWorker failed to clean a dead management pane")
+	}
+	if len(sig.sent) != 0 {
+		t.Errorf("signalled %v from a dead pane; that PID belongs to a process that already exited", sig.sent)
+	}
+}
+
+// A retained dead pane keeps the management session name unavailable until
+// cleanup removes the session.
+func TestDeadMgmtSessionIsReaped(t *testing.T) {
+	st, r := newLivenessTarget(t, true)
+	r.paneDead = true
+	if err := share.SaveState(st.dir, &share.State{SessionID: "$1", ViewURL: "u", UID: "x"}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := cleanupStale(st); err != nil {
+		t.Fatalf("cleanupStale: %v", err)
+	}
+
+	if r.sessionAlive {
+		t.Error("the dead management session was left listed; the next `bitbang share` would fail on duplicate session")
+	}
+	killed := false
+	for _, c := range r.calls {
+		if strings.HasPrefix(c, "kill-session") {
+			killed = true
+			if !strings.Contains(c, "="+st.mgmt) {
+				t.Errorf("kill-session target %q is not anchored", c)
+			}
+		}
+	}
+	if !killed {
+		t.Error("no kill-session was issued for the dead management session")
+	}
+	if _, err := os.Stat(filepath.Join(st.dir, "state.json")); !os.IsNotExist(err) {
+		t.Error("stale state survived cleanup")
+	}
+}
+
+// TestLiveMgmtSessionIsNeverReaped is the other half: a session whose
+// pane is alive holds a running worker, and killing it would take the
+// worker's URLs away with no record left of them.
+func TestLiveMgmtSessionIsNeverReaped(t *testing.T) {
+	st, r := newLivenessTarget(t, true)
+	reapDeadMgmt(st, probeMgmt(st))
+	if !r.sessionAlive {
+		t.Fatal("reapDeadMgmt killed a session with a live pane")
+	}
+}
+
+// TestUnknownProbeNeverCleansUp: a tmux that cannot be run is not an
+// answer. Mapping that to "gone" would delete a live share's state on a
+// transient fork failure.
+func TestUnknownProbeNeverCleansUp(t *testing.T) {
+	// Every caller that can delete state or kill a session, not just
+	// the classifier. stopWorker used to fall through its own guard on
+	// an unknown probe and report success it had not established.
+	callers := map[string]func(*shareTarget){
+		"loadLiveShare": func(st *shareTarget) { loadLiveShare(st) },
+		"stopWorker":    func(st *shareTarget) { stopWorker(st) },
+		"cleanupStale": func(st *shareTarget) {
+			// And it must say so, not refuse in silence: its callers
+			// announce "cleaned up stale state" on the strength of it.
+			if err := cleanupStale(st); err == nil {
+				panic("cleanupStale reported success after refusing to clean up")
+			}
+		},
+	}
+	for name, call := range callers {
+		t.Run(name, func(t *testing.T) {
+			st, r := newLivenessTarget(t, true)
+			r.probeErr = errors.New("tmux list-panes: fork/exec /usr/bin/tmux: resource temporarily unavailable")
+
+			if got := probeMgmt(st); got != mgmtUnknown {
+				t.Fatalf("probeMgmt = %v, want mgmtUnknown when tmux could not be asked", got)
+			}
+			if err := share.SaveState(st.dir, &share.State{SessionID: "$1", ViewURL: "u", UID: "x"}); err != nil {
+				t.Fatal(err)
+			}
+
+			call(st)
+
+			if _, err := os.Stat(filepath.Join(st.dir, "state.json")); err != nil {
+				t.Error("state was deleted after an unanswerable probe")
+			}
+			for _, c := range r.calls {
+				if strings.HasPrefix(c, "kill-session") {
+					t.Error("killed a session tmux could not be asked about")
+				}
+			}
+		})
+	}
+
+	t.Run("stopWorker reports failure", func(t *testing.T) {
+		st, r := newLivenessTarget(t, true)
+		r.probeErr = errors.New("tmux list-panes: no answer")
+		if stopWorker(st) {
+			t.Error("stopWorker reported the share stopped without ever confirming it")
+		}
+	})
+
+	t.Run("classification stays live", func(t *testing.T) {
+		st, r := newLivenessTarget(t, true)
+		r.probeErr = errors.New("tmux list-panes: no answer")
+		if err := share.SaveState(st.dir, &share.State{SessionID: "$1", ViewURL: "u", UID: "x"}); err != nil {
+			t.Fatal(err)
+		}
+		if _, l := loadLiveShare(st); l == shareStale || l == shareAbsent {
+			t.Errorf("liveness = %v, which callers clean up -- a transient probe failure would orphan a live share", l)
+		}
+	})
+}
+
+// signalLog captures what stopWorker would send where, and shrinks the
+// grace periods so a unit test does not sit through them.
+type signalLog struct {
+	sent []string
+}
+
+func captureSignals(t *testing.T) *signalLog {
+	t.Helper()
+	log := &signalLog{}
+	oldKill, oldStop, oldKillGrace := killProcess, stopGrace, killGrace
+	killProcess = func(pid int, sig syscall.Signal) error {
+		log.sent = append(log.sent, fmt.Sprintf("%d:%v", pid, sig))
+		return nil
+	}
+	stopGrace, killGrace = 50*time.Millisecond, 50*time.Millisecond
+	t.Cleanup(func() { killProcess, stopGrace, killGrace = oldKill, oldStop, oldKillGrace })
+	return log
+}
+
+// TestStopWorkerDoesNotEscalateToAReusedPID: between the SIGTERM and
+// the SIGKILL the worker exits, and the kernel is free to hand its
+// number to anything. Five seconds is long enough for that on a machine
+// that cycles PIDs, so the escalation asks tmux again and goes ahead
+// only if the same number is still there.
+func TestStopWorkerDoesNotEscalateToAReusedPID(t *testing.T) {
+	sig := captureSignals(t)
+	st, r := newLivenessTarget(t, true)
+	// First read is the worker; every read after it is whatever took
+	// the number over. The session stays alive so the stop cannot
+	// succeed and has to reach the escalation.
+	r.panePIDs = []int{4242, 5150}
+
+	if stopWorker(st) {
+		t.Fatal("stopWorker reported success while the management pane remained live")
+	}
+
+	for _, s := range sig.sent {
+		if strings.HasSuffix(s, "killed") && !strings.HasPrefix(s, "4242:") {
+			t.Errorf("SIGKILL sent to %s, which is not the process we signalled", s)
+		}
+		if strings.HasPrefix(s, "5150:") {
+			t.Errorf("signalled %s -- that PID belongs to whatever reused the number", s)
+		}
+	}
+	if len(sig.sent) != 1 || !strings.HasPrefix(sig.sent[0], "4242:") {
+		t.Errorf("signals sent = %v, want exactly one SIGTERM to the worker", sig.sent)
+	}
+}
+
+// TestStopWorkerEscalatesToTheSameWorker is the other half: a worker
+// that ignores SIGTERM and is still the pane's process does get killed.
+func TestStopWorkerEscalatesToTheSameWorker(t *testing.T) {
+	sig := captureSignals(t)
+	st, r := newLivenessTarget(t, true)
+	r.panePIDs = []int{4242}
+
+	if stopWorker(st) {
+		t.Fatal("stopWorker reported success while the fake worker remained live")
+	}
+
+	if len(sig.sent) != 2 || sig.sent[0] != "4242:terminated" || sig.sent[1] != "4242:killed" {
+		t.Errorf("signals sent = %v, want SIGTERM then SIGKILL to 4242", sig.sent)
+	}
+}
+
+func TestWaitForStateRejectsAnotherStartsState(t *testing.T) {
+	st, _ := newLivenessTarget(t, true)
+	if err := share.SaveState(st.dir, &share.State{
+		SessionID: "$1", ViewURL: "https://old.example/#dead", UID: "u", Nonce: "a-previous-start",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := waitForState(st, "this-start", 300*time.Millisecond); err == nil {
+		t.Fatal("waitForState handed back a previous start's state as this start's")
+	}
+}
+
+func TestWaitForStateRequiresALiveWorker(t *testing.T) {
+	st, r := newLivenessTarget(t, true)
+	r.paneDead = true
+	if err := share.SaveState(st.dir, &share.State{
+		SessionID: "$1", ViewURL: "https://x.example/#y", UID: "u", Nonce: "this-start",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	_, err := waitForState(st, "this-start", 5*time.Second)
+	if err == nil {
+		t.Fatal("waitForState reported a worker ready after it had already exited")
+	}
+	if !strings.Contains(err.Error(), "exited") {
+		t.Errorf("error = %q, want it to say the worker exited", err)
+	}
+}
+
+func TestWaitForStateAcceptsThisStart(t *testing.T) {
+	st, _ := newLivenessTarget(t, true)
+	want := &share.State{
+		SessionID: "$1", ViewURL: "https://x.example/#y", UID: "u", Nonce: "this-start",
+	}
+	if err := share.SaveState(st.dir, want); err != nil {
+		t.Fatal(err)
+	}
+	got, err := waitForState(st, "this-start", 5*time.Second)
+	if err != nil {
+		t.Fatalf("waitForState: %v", err)
+	}
+	if got.ViewURL != want.ViewURL {
+		t.Errorf("ViewURL = %q, want %q", got.ViewURL, want.ViewURL)
+	}
+}
+
+func TestWaitForStateOutlastsAnUnansweredProbe(t *testing.T) {
+	st, r := newLivenessTarget(t, true)
+	r.probeErr = errors.New("tmux list-panes: fork/exec: resource temporarily unavailable")
+
+	start := time.Now()
+	_, err := waitForState(st, "this-start", 400*time.Millisecond)
+	if err == nil {
+		t.Fatal("expected the wait to run out")
+	}
+	if strings.Contains(err.Error(), "exited") {
+		t.Errorf("error = %q, but nothing established that the worker exited", err)
+	}
+	if elapsed := time.Since(start); elapsed < 300*time.Millisecond {
+		t.Errorf("gave up after %s; an unanswered probe should not cut the wait short", elapsed)
+	}
+}
+
+// If the pane exits after SIGTERM, its PID must not receive SIGKILL.
+func TestStopWorkerDoesNotEscalateToAVanishedPane(t *testing.T) {
+	sig := captureSignals(t)
+	st, r := newLivenessTarget(t, true)
+	r.panePIDs = []int{4242}
+	// Alive for the PID read and the first wait, gone by the time the
+	// escalation looks again.
+	r.dieAfterProbes = 2
+
+	if !stopWorker(st) {
+		t.Fatal("stopWorker reported failure against a worker that exited")
+	}
+	if len(sig.sent) != 1 || sig.sent[0] != "4242:terminated" {
+		t.Errorf("signals sent = %v, want only the SIGTERM; the pane was gone before the escalation", sig.sent)
+	}
+}
+
+// TestUnreachableServerIsNotAnAnswer is the counterexample to reading a
+// tmux exit status as a verdict. A live server whose socket has become
+// inaccessible answers every command with exit 1 -- `error connecting to
+// PATH (Permission denied)` -- which is indistinguishable from the
+// session being gone, while the session is in fact still running.
+// Reproduced against a real server with chmod 000 on its socket.
+//
+// The session stays ALIVE in this fake on purpose. That is the whole
+// case: the answer the classifier must not give is "gone", about a
+// worker that is sitting there serving. Only the listing failed.
+func TestUnreachableServerIsNotAnAnswer(t *testing.T) {
+	t.Run("classified unknown", func(t *testing.T) {
+		st, r := newLivenessTarget(t, true) // the worker is running...
+		r.serverUnreachable = true          // ...and the listing cannot say so
+		if got := probeMgmt(st); got != mgmtUnknown {
+			t.Errorf("probeMgmt = %v, want mgmtUnknown; the session may be alive behind an unreachable socket", got)
+		}
+	})
+
+	t.Run("server answers, target really is absent", func(t *testing.T) {
+		st, r := newLivenessTarget(t, false)
+		r.serverUnreachable = false
+		if got := probeMgmt(st); got != mgmtGone {
+			t.Errorf("probeMgmt = %v, want mgmtGone; the server answered and it has no such session", got)
+		}
+	})
+
+	t.Run("state survives", func(t *testing.T) {
+		st, r := newLivenessTarget(t, true)
+		r.serverUnreachable = true
+		if err := share.SaveState(st.dir, &share.State{SessionID: "$1", ViewURL: "u", UID: "x"}); err != nil {
+			t.Fatal(err)
+		}
+		if stopWorker(st) {
+			t.Error("stopWorker reported success without reaching the server")
+		}
+		if err := cleanupStale(st); err == nil {
+			t.Error("cleanupStale reported success without ever reaching the server")
+		}
+		if _, err := os.Stat(filepath.Join(st.dir, "state.json")); err != nil {
+			t.Error("a live share's state was deleted because tmux exited 1 for an unrelated reason")
+		}
+	})
+}
+
+// TestLockSerializesTargetLifecycle: classification, cleanup, session
+// creation and accepting published state are individually safe and
+// unsafe together -- a second command can replace the target between any
+// two of them. The lock is what makes the sequence one turn.
+func TestLockSerializesTargetLifecycle(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "target.lock")
+
+	first, _, err := share.TryLock(path)
+	if err != nil {
+		t.Fatalf("first acquire: %v", err)
+	}
+	if _, holder, err := share.TryLock(path); !errors.Is(err, share.ErrLockBusy) {
+		t.Errorf("second acquire = %v (holder %d), want ErrLockBusy", err, holder)
+	}
+	first.Release()
+	second, _, err := share.TryLock(path)
+	if err != nil {
+		t.Fatalf("acquire after release: %v", err)
+	}
+	second.Release()
+}
+
+// TestLockOutlivesTheStateDirectory: cleanup removes the state
+// directory while the lock is held. A lock file inside it would be
+// deleted mid-sequence, and the next process would create a fresh file
+// at the same path and lock that instead -- excluding nobody.
+func TestLockOutlivesTheStateDirectory(t *testing.T) {
+	st, _ := newLivenessTarget(t, false)
+	if !strings.HasPrefix(st.dir, filepath.Dir(st.lock)) {
+		t.Fatalf("test setup: lock %q is not beside state dir %q", st.lock, st.dir)
+	}
+	if strings.HasPrefix(st.lock, st.dir+string(filepath.Separator)) {
+		t.Errorf("lock %q lives inside the state directory %q, which cleanup deletes", st.lock, st.dir)
+	}
+}
+
+// TestEveryCommandTakesTheTargetLock is the wiring test. The flock unit
+// test above proves only the primitive -- it would pass with every
+// enterTarget call deleted, which is exactly the part that matters. So
+// this holds the target's lock from outside and checks that each public
+// command refuses to proceed.
+//
+// It holds the lock rather than racing two real starts: racing them
+// meant waiting out the production startup timeout, sixteen seconds per
+// run, and it only ever exercised one command.
+func TestEveryCommandTakesTheTargetLock(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	for _, bin := range []string{"tmux", "go"} {
+		if _, err := exec.LookPath(bin); err != nil {
+			t.Skipf("%s not installed", bin)
+		}
+	}
+
+	// Short base path: a Unix socket path is capped near 104 bytes.
+	base, err := os.MkdirTemp("/tmp", "bblock")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(base) })
+
+	bb := filepath.Join(base, "bb")
+	if out, err := exec.Command("go", "build", "-o", bb, ".").CombinedOutput(); err != nil {
+		t.Skipf("cannot build the CLI under test: %v\n%s", err, out)
+	}
+
+	socket := filepath.Join(base, "s")
+	home := filepath.Join(base, "home")
+	if err := os.MkdirAll(home, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	tmux := func(args ...string) *exec.Cmd {
+		return exec.Command("tmux", append([]string{"-S", socket}, args...)...)
+	}
+	if err := tmux("new-session", "-d", "-s", "work", "cat").Run(); err != nil {
+		t.Skipf("cannot start an isolated tmux server: %v", err)
+	}
+	t.Cleanup(func() { _ = tmux("kill-server").Run() })
+
+	// Derive the same lock path the CLI will, from the server's own
+	// answers, so this fails loudly if that derivation ever changes.
+	idOut, err := tmux("display-message", "-p", "-t", "=work:", "#{session_id}\t#{socket_path}").Output()
+	if err != nil {
+		t.Fatalf("display-message: %v", err)
+	}
+	fields := strings.Split(strings.TrimSpace(string(idOut)), "\t")
+	if len(fields) < 2 {
+		t.Fatalf("unexpected display-message output %q", idOut)
+	}
+	hash := share.TargetHash(fields[1], fields[0])
+	lockPath := filepath.Join(home, ".bitbang", "shares", hash+".lock")
+	if err := os.MkdirAll(filepath.Dir(lockPath), 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	held, _, err := share.TryLock(lockPath)
+	if err != nil {
+		t.Fatalf("TryLock: %v", err)
+	}
+	defer held.Release()
+
+	for _, args := range [][]string{
+		{"share"},
+		{"share", "status"},
+		{"share", "stop"},
+		{"share", "rotate"},
+	} {
+		full := append(append([]string{}, args...), "--target", "work", "--socket", socket,
+			"--server", "nonexistent.invalid", "--ttl", "1m")
+		cmd := exec.Command(bb, full...)
+		cmd.Env = append(os.Environ(), "HOME="+home)
+		out, err := cmd.CombinedOutput()
+		if err == nil {
+			t.Errorf("`%s` ran to completion while the target lock was held:\n%s",
+				strings.Join(args, " "), out)
+			continue
+		}
+		if !strings.Contains(string(out), "Another `bitbang share` command is working") {
+			t.Errorf("`%s` did not take the target lock; it failed with:\n%s",
+				strings.Join(args, " "), out)
+		}
+	}
+
+	// Nothing may have been created or destroyed while it was locked out.
+	sessions, _ := tmux("list-sessions", "-F", "#{session_name}").Output()
+	if strings.Contains(string(sessions), "_bbshare_") {
+		t.Errorf("a locked-out command still created a management session: %s", sessions)
+	}
+}
+
+// TestSweepRemovesUnreachableState: a worker whose *source* session was
+// deleted leaves state no ordinary command can reach -- resolving a
+// target begins by asking tmux for a session ID that no longer exists,
+// and a new session of the same name hashes elsewhere. Anything left by
+// a worker that was killed outright is in the same position. The sweep
+// is the only thing that collects either.
+func TestSweepRemovesUnreachableState(t *testing.T) {
+	// Short base path: the recorded socket has to be one connect()
+	// could actually have reached, or "no server there" is untestable --
+	// a path past the sockaddr_un limit fails with EINVAL, which is not
+	// an answer and is deliberately not treated as one.
+	base, err := os.MkdirTemp("/tmp", "bbsweep")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(base) })
+	t.Setenv("HOME", base)
+	shares := filepath.Join(base, ".bitbang", "shares")
+	if err := os.MkdirAll(shares, 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	// A share on a socket that no longer exists: its management session
+	// cannot be listed, so nothing is running for it.
+	stranded := filepath.Join(shares, "deadbeef")
+	if err := share.SaveState(stranded, &share.State{
+		Socket: filepath.Join(base, "gone.sock"), SessionID: "$0", SessionName: "work",
+		MgmtSession: "_bbshare_deadbeef", ViewURL: "https://x.example/#dead", UID: "u",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	// An empty directory and an orphaned lock, the other two ways a
+	// killed command leaves litter.
+	empty := filepath.Join(shares, "cafe0000")
+	if err := os.MkdirAll(empty, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	orphanLock := filepath.Join(shares, "f00d0000.lock")
+	if err := os.WriteFile(orphanLock, []byte("1\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	// And the target this command is here for, which must be untouched.
+	mine := filepath.Join(shares, "myhash")
+	if err := share.SaveState(mine, &share.State{
+		SessionID: "$1", MgmtSession: "_bbshare_myhash", ViewURL: "https://x.example/#mine", UID: "u",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	sweepStranded(mine)
+
+	if _, err := os.Stat(stranded); !os.IsNotExist(err) {
+		t.Error("state for a share on a vanished server survived the sweep; nothing else can ever reach it")
+	}
+	if _, err := os.Stat(empty); !os.IsNotExist(err) {
+		t.Error("an empty share directory survived the sweep")
+	}
+	if _, err := os.Stat(orphanLock); !os.IsNotExist(err) {
+		t.Error("a lock file with no target survived the sweep")
+	}
+	if _, err := os.Stat(filepath.Join(mine, "state.json")); err != nil {
+		t.Error("the sweep removed the state of the target the command is working on")
+	}
+}
+
+// TestSweepLeavesWhatItCannotAccountFor: the sweep deletes credential
+// files, so silence is never evidence. A live share, a state file it
+// cannot read, and a directory another command holds the lock on all
+// have to survive.
+func TestSweepLeavesWhatItCannotAccountFor(t *testing.T) {
+	if _, err := exec.LookPath("tmux"); err != nil {
+		t.Skip("tmux not installed")
+	}
+	base, err := os.MkdirTemp("/tmp", "bbsweep")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(base) })
+	t.Setenv("HOME", base)
+	shares := filepath.Join(base, ".bitbang", "shares")
+	if err := os.MkdirAll(shares, 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	socket := filepath.Join(base, "s")
+	tmux := func(args ...string) *exec.Cmd {
+		return exec.Command("tmux", append([]string{"-S", socket}, args...)...)
+	}
+	if err := tmux("new-session", "-d", "-s", "_bbshare_live", "cat").Run(); err != nil {
+		t.Skipf("cannot start an isolated tmux server: %v", err)
+	}
+	t.Cleanup(func() { _ = tmux("kill-server").Run() })
+
+	live := filepath.Join(shares, "live")
+	if err := share.SaveState(live, &share.State{
+		Socket: socket, SessionID: "$0", MgmtSession: "_bbshare_live",
+		ViewURL: "https://x.example/#live", UID: "u",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	unreadable := filepath.Join(shares, "unreadable")
+	if err := os.MkdirAll(unreadable, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(unreadable, "state.json"), []byte("{broken"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	// A directory another command is working on: no state yet, because
+	// it has not published, and the lock is what says so.
+	busy := filepath.Join(shares, "busy")
+	if err := os.MkdirAll(busy, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	busyLock, _, err := share.TryLock(share.LockPathFor(busy))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer busyLock.Release()
+
+	sweepStranded(filepath.Join(shares, "somewhere-else"))
+
+	if _, err := os.Stat(filepath.Join(live, "state.json")); err != nil {
+		t.Error("the sweep deleted a live share's credentials")
+	}
+	if _, err := os.Stat(filepath.Join(unreadable, "state.json")); err != nil {
+		t.Error("the sweep deleted state it could not read, which names no server to check")
+	}
+	if _, err := os.Stat(busy); err != nil {
+		t.Error("the sweep deleted a directory another command held the lock on")
+	}
+}
+
+// TestServerIsGoneOnlyOnProof: the sweep deletes credential files on
+// this answer, and tmux renders all three of these conditions as the
+// same exit status, so the errno is what has to separate them. Built on
+// plain unix sockets -- no tmux needed to establish what connect() says.
+func TestServerIsGoneOnlyOnProof(t *testing.T) {
+	base, err := os.MkdirTemp("/tmp", "bbsock")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(base) })
+
+	t.Run("no socket at all", func(t *testing.T) {
+		if !serverIsGone(filepath.Join(base, "never-existed")) {
+			t.Error("a path with nothing at it was not recognised as having no server")
+		}
+	})
+
+	t.Run("something listening", func(t *testing.T) {
+		path := filepath.Join(base, "live")
+		ln, err := net.Listen("unix", path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer ln.Close()
+		if serverIsGone(path) {
+			t.Error("a socket with a listener was called gone")
+		}
+	})
+
+	t.Run("stale socket, nothing listening", func(t *testing.T) {
+		// A tmux socket file may outlive its server.
+		path := filepath.Join(base, "stale")
+		ln, err := net.Listen("unix", path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if unixLn, ok := ln.(*net.UnixListener); ok {
+			unixLn.SetUnlinkOnClose(false)
+		}
+		_ = ln.Close()
+		if _, err := os.Stat(path); err != nil {
+			t.Skipf("could not stage a stale socket: %v", err)
+		}
+		if !serverIsGone(path) {
+			t.Error("a socket with nothing listening was not recognised as having no server")
+		}
+	})
+
+	t.Run("unreachable socket", func(t *testing.T) {
+		if os.Getuid() == 0 {
+			t.Skip("root connects whatever the mode")
+		}
+		path := filepath.Join(base, "forbidden")
+		ln, err := net.Listen("unix", path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer ln.Close()
+		if err := os.Chmod(path, 0o000); err != nil {
+			t.Skipf("cannot restrict the socket: %v", err)
+		}
+		if serverIsGone(path) {
+			t.Error("a live server behind an inaccessible socket was called gone; its share would lose its only record")
+		}
+	})
+}
+
+// sweepFixture stands up a real tmux server plus a shares directory,
+// since what the sweep decides is exactly what tmux tells it.
+type sweepFixture struct {
+	socket string
+	shares string
+	tmux   func(args ...string) *exec.Cmd
+}
+
+func newSweepFixture(t *testing.T) *sweepFixture {
+	t.Helper()
+	if _, err := exec.LookPath("tmux"); err != nil {
+		t.Skip("tmux not installed")
+	}
+	// Short base path: a Unix socket path is capped near 104 bytes.
+	base, err := os.MkdirTemp("/tmp", "bbswp")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(base) })
+	t.Setenv("HOME", base)
+
+	f := &sweepFixture{socket: filepath.Join(base, "s"), shares: filepath.Join(base, ".bitbang", "shares")}
+	f.tmux = func(args ...string) *exec.Cmd {
+		return exec.Command("tmux", append([]string{"-S", f.socket}, args...)...)
+	}
+	if err := os.MkdirAll(f.shares, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	// A session that outlives the shares, so the server stays up to be
+	// asked -- as the worker's own management session does in production.
+	if err := f.tmux("new-session", "-d", "-s", "keep-alive", "cat").Run(); err != nil {
+		t.Skipf("cannot start an isolated tmux server: %v", err)
+	}
+	t.Cleanup(func() { _ = f.tmux("kill-server").Run() })
+	return f
+}
+
+func (f *sweepFixture) writeState(t *testing.T, name, mgmt string) string {
+	t.Helper()
+	dir := filepath.Join(f.shares, name)
+	if err := share.SaveState(dir, &share.State{
+		Socket: f.socket, SessionID: "$9", SessionName: "work", MgmtSession: mgmt,
+		ViewURL: "https://x.example/#" + name, UID: "u",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+// Start a share between sweep entries and ensure its liveness is checked only
+// after the sweep takes that target's lock.
+func TestSweepReadsLivenessAfterTakingEachLock(t *testing.T) {
+	f := newSweepFixture(t)
+
+	// Processed first, and genuinely stale: nothing by that name runs.
+	stale := f.writeState(t, "aaa", "_bbshare_aaa")
+	// Processed second. Its session does not exist yet.
+	fresh := f.writeState(t, "zzz", "_bbshare_zzz")
+
+	started := false
+	old := sweepStep
+	sweepStep = func() {
+		if started {
+			return
+		}
+		started = true
+		if err := f.tmux("new-session", "-d", "-s", "_bbshare_zzz", "cat").Run(); err != nil {
+			t.Errorf("new-session: %v", err)
+		}
+	}
+	t.Cleanup(func() { sweepStep = old })
+
+	sweepStranded(filepath.Join(f.shares, "not-a-target"))
+
+	if _, err := os.Stat(stale); !os.IsNotExist(err) {
+		t.Error("a genuinely stale directory survived; the sweep is not doing its job at all")
+	}
+	if _, err := os.Stat(filepath.Join(fresh, "state.json")); err != nil {
+		t.Error("the sweep deleted a share that came up while it was working, " +
+			"which means the verdict was read before that target's lock was taken")
+	}
+}
+
+// TestSweepReapsRetainedHusk: with a global remain-on-exit, a dead
+// worker's management session stays listed. Reading only session names
+// counted that as running and preserved it forever -- and when the
+// source session is what disappeared, no targeted command can ever come
+// back for it, so the state and the husk both sit there permanently.
+func TestSweepReapsRetainedHusk(t *testing.T) {
+	f := newSweepFixture(t)
+	if err := f.tmux("set", "-g", "remain-on-exit", "on").Run(); err != nil {
+		t.Fatal(err)
+	}
+	if err := f.tmux("new-session", "-d", "-s", "_bbshare_husk", "true").Run(); err != nil {
+		t.Fatal(err)
+	}
+	dir := f.writeState(t, "husk", "_bbshare_husk")
+
+	// Wait for the pane to actually be dead, not merely started.
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		out, _ := f.tmux("list-panes", "-t", "=_bbshare_husk:", "-F", "#{pane_dead}").Output()
+		if strings.Contains(string(out), "1") {
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	sweepStranded(filepath.Join(f.shares, "not-a-target"))
+
+	if _, err := os.Stat(dir); !os.IsNotExist(err) {
+		t.Error("a dead worker's state survived because its husk was still listed")
+	}
+	out, _ := f.tmux("list-sessions", "-F", "#{session_name}").Output()
+	if strings.Contains(string(out), "_bbshare_husk") {
+		t.Errorf("the husk was left holding its name, which blocks the next share: %s", out)
+	}
+}
+
+// TestSweepLeavesALiveShareOnTheSameServer is the converse, and the one
+// that matters most: a running share must survive a sweep triggered by
+// something else entirely.
+func TestSweepLeavesALiveShareOnTheSameServer(t *testing.T) {
+	f := newSweepFixture(t)
+	if err := f.tmux("new-session", "-d", "-s", "_bbshare_live", "cat").Run(); err != nil {
+		t.Fatal(err)
+	}
+	live := f.writeState(t, "live", "_bbshare_live")
+	stale := f.writeState(t, "stale", "_bbshare_stale")
+
+	sweepStranded(filepath.Join(f.shares, "not-a-target"))
+
+	if _, err := os.Stat(filepath.Join(live, "state.json")); err != nil {
+		t.Error("the sweep deleted a running share's credentials")
+	}
+	if _, err := os.Stat(stale); !os.IsNotExist(err) {
+		t.Error("the stale directory beside it survived")
+	}
+}
+
+// A process that accepts the old socket but never speaks tmux must not block
+// share commands indefinitely.
+func TestSweepDoesNotHangOnAWedgedSocket(t *testing.T) {
+	f := newSweepFixture(t)
+	old := sweepProbeTimeout
+	sweepProbeTimeout = 300 * time.Millisecond
+	t.Cleanup(func() { sweepProbeTimeout = old })
+
+	wedged := filepath.Join(filepath.Dir(f.shares), "wedged.sock")
+	ln, err := net.Listen("unix", wedged)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ln.Close()
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			_ = conn // accepted and then ignored, forever
+		}
+	}()
+
+	dir := filepath.Join(f.shares, "wedged")
+	if err := share.SaveState(dir, &share.State{
+		Socket: wedged, SessionID: "$9", MgmtSession: "_bbshare_wedged",
+		ViewURL: "https://x.example/#w", UID: "u",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	done := make(chan struct{})
+	go func() { sweepStranded(filepath.Join(f.shares, "not-a-target")); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("the sweep hung on a socket that accepts connections and never answers")
+	}
+
+	if _, err := os.Stat(filepath.Join(dir, "state.json")); err != nil {
+		t.Error("state was deleted on a probe that timed out, which established nothing")
+	}
+}
+
+// Multiple wedged sockets must still respect the total sweep budget.
+func TestSweepStaysWithinItsBudget(t *testing.T) {
+	f := newSweepFixture(t)
+	oldProbe, oldBudget := sweepProbeTimeout, sweepBudget
+	sweepProbeTimeout, sweepBudget = 200*time.Millisecond, 300*time.Millisecond
+	t.Cleanup(func() { sweepProbeTimeout, sweepBudget = oldProbe, oldBudget })
+
+	const wedged = 5
+	for i := range wedged {
+		sock := filepath.Join(filepath.Dir(f.shares), fmt.Sprintf("wedged%d.sock", i))
+		ln, err := net.Listen("unix", sock)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer ln.Close()
+		go func() {
+			for {
+				conn, err := ln.Accept()
+				if err != nil {
+					return
+				}
+				_ = conn // accepted and then ignored, forever
+			}
+		}()
+		dir := filepath.Join(f.shares, fmt.Sprintf("wedged%d", i))
+		if err := share.SaveState(dir, &share.State{
+			Socket: sock, SessionID: "$9", MgmtSession: "_bbshare_w",
+			ViewURL: "https://x.example/#w", UID: "u",
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	start := time.Now()
+	sweepStranded(filepath.Join(f.shares, "not-a-target"))
+	elapsed := time.Since(start)
+
+	// Unbounded, five entries would cost 5 x (200ms + 200ms + 200ms).
+	// The budget stops after the first that overruns it.
+	if elapsed > 1500*time.Millisecond {
+		t.Errorf("the sweep took %s; pathological entries are stacking in front of the caller", elapsed)
+	}
+
+	// And nothing may be deleted on the way: every one of those probes
+	// timed out, which establishes nothing at all.
+	//
+	// (The delay is also reported once -- see the log line in
+	// sweepStranded -- because a share nothing can account for is kept
+	// correctly, and then paid for on every command from here on.)
+	for i := range wedged {
+		path := filepath.Join(f.shares, fmt.Sprintf("wedged%d", i), "state.json")
+		if _, err := os.Stat(path); err != nil {
+			t.Errorf("state %d was deleted after a probe that only ran out of time", i)
+		}
+	}
+}

--- a/internal/client/reject_e2e_test.go
+++ b/internal/client/reject_e2e_test.go
@@ -1,0 +1,63 @@
+package client
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/richlegrand/bitbang/internal/identity"
+)
+
+// TestDial_WrongAccessCode_FailsFast is a regression test for a hang:
+// when a listener rejects the connection it closes the data channel
+// without ever sending verify_nonce_hash, and the client used to block
+// forever waiting for that frame (the dial timeout only covers channel
+// *open*, which succeeds -- DTLS completes before verification runs).
+//
+// It matters most for `bitbang share`, whose URLs get pasted around
+// and expire, so a stale or mistyped code is the common case rather
+// than the exotic one.
+func TestDial_WrongAccessCode_FailsFast(t *testing.T) {
+	if testing.Short() {
+		t.Skip("e2e: spins up real pion peer connections")
+	}
+	relay := newFakeSignaling()
+	defer relay.Close()
+
+	id := ephemeralID(t)
+	startListener(relay.host(), id)
+	waitRegistered(t, relay)
+
+	// Same UID, wrong code -- exactly what a stale share link looks like.
+	wrong, err := identity.Load("bitbang-e2e-wrongcode", true)
+	if err != nil {
+		t.Fatalf("identity.Load: %v", err)
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		_, dialErr := Dial(DialOptions{
+			Server:      relay.host(),
+			UID:         id.UID,
+			Code:        wrong.Code,
+			Path:        "/",
+			Caps:        []string{"shell"},
+			DialTimeout: 15 * time.Second,
+		})
+		done <- dialErr
+	}()
+
+	select {
+	case dialErr := <-done:
+		if dialErr == nil {
+			t.Fatal("Dial succeeded with a wrong access code")
+		}
+		// The message has to point at the credential -- "timeout" alone
+		// would send users chasing a network problem they don't have.
+		if !strings.Contains(dialErr.Error(), "access code") {
+			t.Errorf("error %q does not name the access code as the cause", dialErr)
+		}
+	case <-time.After(handshakeTimeout + 20*time.Second):
+		t.Fatal("Dial hung after the listener rejected the access code")
+	}
+}

--- a/internal/client/session.go
+++ b/internal/client/session.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	"github.com/pion/webrtc/v4"
 
@@ -36,6 +37,12 @@ type Session struct {
 	ServerCaps    []string
 	ServerVersion int
 
+	// ServerAccess is the per-peer access level from `ready` ("control"
+	// or "view" for a bitbang share; "" from listeners without roles).
+	// Advisory for UX only: a "view" client should stop transmitting
+	// input, but the listener enforces the role regardless.
+	ServerAccess protocol.Access
+
 	nextStreamID uint32
 	mu           sync.Mutex
 	streams      map[uint32]*stream
@@ -63,6 +70,44 @@ func newSession(p *Peer) *Session {
 	}
 }
 
+// handshakeTimeout bounds each wait for a control frame during the
+// post-DTLS handshake. The listener answers verify/connect
+// immediately, so this only has to cover a slow link; the clock is
+// restarted after every frame received and after an interactive PIN
+// prompt returns, so a human typing slowly can't trip it.
+const handshakeTimeout = 30 * time.Second
+
+// recvControl waits for the next handshake frame, distinguishing the
+// three ways the wait can end. Without the DCClosed and timeout arms
+// a listener that rejects the connection (wrong access code, expired
+// share, or fingerprint mismatch) closes the channel without ever
+// sending a frame, and the client blocks forever.
+func recvControl(p *Peer, timeout time.Duration) ([]byte, error) {
+	// Prefer a buffered frame over a close that landed alongside it,
+	// so a listener's final message isn't lost to a random select.
+	select {
+	case msg, ok := <-p.DCMessages():
+		if ok {
+			return msg, nil
+		}
+		return nil, errors.New("data channel closed during handshake")
+	default:
+	}
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+	select {
+	case msg, ok := <-p.DCMessages():
+		if !ok {
+			return nil, errors.New("data channel closed during handshake")
+		}
+		return msg, nil
+	case <-p.DCClosed():
+		return nil, errors.New("listener closed the connection without completing verification; the access code is wrong or no longer valid")
+	case <-timer.C:
+		return nil, fmt.Errorf("listener did not complete the handshake within %s", timeout)
+	}
+}
+
 // handshake runs the client-side control protocol after the data channel
 // opens: verify_nonce_hash → connect → (auth_required + auth)* → ready.
 // Returns once `ready` arrives or the channel dies.
@@ -72,9 +117,9 @@ func newSession(p *Peer) *Session {
 // implementation that uses golang.org/x/term to hide the input.
 func (s *Session) handshake(p *Peer, path string, caps []string, pinPrompt func(retry int) (string, error)) error {
 	// 1. verify_nonce_hash must be the *first* control frame.
-	first, ok := <-p.DCMessages()
-	if !ok {
-		return errors.New("data channel closed before verify")
+	first, err := recvControl(p, handshakeTimeout)
+	if err != nil {
+		return err
 	}
 	frame, err := protocol.ParseFrame(first)
 	if err != nil {
@@ -118,9 +163,9 @@ func (s *Session) handshake(p *Peer, path string, caps []string, pinPrompt func(
 	// a small cap.
 	retry := 0
 	for {
-		msg, ok := <-p.DCMessages()
-		if !ok {
-			return errors.New("data channel closed during handshake")
+		msg, err := recvControl(p, handshakeTimeout)
+		if err != nil {
+			return err
 		}
 		f, err := protocol.ParseFrame(msg)
 		if err != nil {
@@ -136,11 +181,12 @@ func (s *Session) handshake(p *Peer, path string, caps []string, pinPrompt func(
 			continue
 		}
 		var ctl struct {
-			Type          string   `json:"type"`
-			Message       string   `json:"message"`
-			Success       bool     `json:"success"`
-			Caps          []string `json:"caps"`
-			ServerVersion int      `json:"server_version"`
+			Type          string          `json:"type"`
+			Message       string          `json:"message"`
+			Success       bool            `json:"success"`
+			Caps          []string        `json:"caps"`
+			ServerVersion int             `json:"server_version"`
+			Access        protocol.Access `json:"access"`
 		}
 		_ = json.Unmarshal(f.Payload, &ctl)
 
@@ -148,6 +194,7 @@ func (s *Session) handshake(p *Peer, path string, caps []string, pinPrompt func(
 		case "ready":
 			s.ServerCaps = ctl.Caps
 			s.ServerVersion = ctl.ServerVersion
+			s.ServerAccess = ctl.Access
 			if s.ServerVersion == 0 {
 				// v2 listeners send {type:"ready"} with no version.
 				s.ServerVersion = 2

--- a/internal/peer/authorize_test.go
+++ b/internal/peer/authorize_test.go
@@ -1,0 +1,207 @@
+package peer
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"testing"
+
+	"github.com/pion/webrtc/v4"
+
+	"github.com/richlegrand/bitbang/internal/identity"
+	"github.com/richlegrand/bitbang/internal/protocol"
+)
+
+// answeringPair builds a real offerer/answerer SDP exchange so
+// HandleAnswer runs against a genuine PeerConnection (SetRemoteDescription
+// rejects an answer that doesn't match the local offer). No ICE
+// connectivity is needed -- the test stops at SDP + verify.
+func answeringPair(t *testing.T, id *identity.Identity) (*Connection, string) {
+	t.Helper()
+
+	offerPC, err := webrtc.NewPeerConnection(webrtc.Configuration{})
+	if err != nil {
+		t.Fatalf("offer PC: %v", err)
+	}
+	t.Cleanup(func() { _ = offerPC.Close() })
+	if _, err := offerPC.CreateDataChannel("http", nil); err != nil {
+		t.Fatalf("data channel: %v", err)
+	}
+	offer, err := offerPC.CreateOffer(nil)
+	if err != nil {
+		t.Fatalf("create offer: %v", err)
+	}
+	if err := offerPC.SetLocalDescription(offer); err != nil {
+		t.Fatalf("set local description: %v", err)
+	}
+
+	answerPC, err := webrtc.NewPeerConnection(webrtc.Configuration{})
+	if err != nil {
+		t.Fatalf("answer PC: %v", err)
+	}
+	t.Cleanup(func() { _ = answerPC.Close() })
+	if err := answerPC.SetRemoteDescription(*offerPC.LocalDescription()); err != nil {
+		t.Fatalf("answerer set remote: %v", err)
+	}
+	answer, err := answerPC.CreateAnswer(nil)
+	if err != nil {
+		t.Fatalf("create answer: %v", err)
+	}
+	if err := answerPC.SetLocalDescription(answer); err != nil {
+		t.Fatalf("answerer set local: %v", err)
+	}
+
+	conn := &Connection{ClientID: "client-1", PC: offerPC, identity: id}
+	return conn, answerPC.LocalDescription().SDP
+}
+
+// encryptedRequest builds the browser-side payload HandleAnswer expects.
+func encryptedRequest(t *testing.T, id *identity.Identity, sdp, code string) string {
+	t.Helper()
+	payload, _ := json.Marshal(map[string]string{
+		"fingerprint": extractFingerprint(sdp),
+		"nonce":       base64.StdEncoding.EncodeToString([]byte("0123456789abcdef")),
+		"code":        code,
+	})
+	ct, err := encryptToPubkey(t, id, payload)
+	if err != nil {
+		t.Fatalf("encrypt: %v", err)
+	}
+	return base64.StdEncoding.EncodeToString(ct)
+}
+
+// TestAuthorizeGrantsAccessLevel is the core of `bitbang share`'s
+// two-credential model: one UID, two codes, each mapping to a role
+// that HandleAnswer records before any session exists.
+func TestAuthorizeGrantsAccessLevel(t *testing.T) {
+	id, err := identity.Load("bitbang-authorize-test", true)
+	if err != nil {
+		t.Fatalf("identity: %v", err)
+	}
+	const viewCode = "VIEWCODE123"
+
+	for _, tc := range []struct {
+		name, code string
+		wantAccess protocol.Access
+	}{
+		{"control code", id.Code, protocol.AccessControl},
+		{"view code", viewCode, protocol.AccessView},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			conn, answerSDP := answeringPair(t, id)
+			conn.Authorize = func(code string) (protocol.Access, bool) {
+				switch code {
+				case id.Code:
+					return protocol.AccessControl, true
+				case viewCode:
+					return protocol.AccessView, true
+				}
+				return "", false
+			}
+
+			if err := conn.HandleAnswer(answerSDP, encryptedRequest(t, id, answerSDP, tc.code)); err != nil {
+				t.Fatalf("HandleAnswer: %v", err)
+			}
+			if got := conn.Access(); got != tc.wantAccess {
+				t.Errorf("Access() = %q, want %q", got, tc.wantAccess)
+			}
+			conn.mu.Lock()
+			failed, nonce := conn.verifyFailed, conn.nonce
+			conn.mu.Unlock()
+			if failed {
+				t.Error("verifyFailed set for an authorized peer")
+			}
+			if nonce == nil {
+				t.Error("nonce not recorded -- the data channel would close on open")
+			}
+		})
+	}
+}
+
+// TestAuthorizeRejectsUnknownCode: a guess that matches neither role
+// must fail exactly like a bad single-code connection does.
+func TestAuthorizeRejectsUnknownCode(t *testing.T) {
+	id, err := identity.Load("bitbang-authorize-reject", true)
+	if err != nil {
+		t.Fatalf("identity: %v", err)
+	}
+	conn, answerSDP := answeringPair(t, id)
+	called := 0
+	conn.Authorize = func(string) (protocol.Access, bool) {
+		called++
+		return "", false
+	}
+
+	err = conn.HandleAnswer(answerSDP, encryptedRequest(t, id, answerSDP, "WRONGCODE00"))
+	if err == nil {
+		t.Fatal("HandleAnswer accepted an unauthorized code")
+	}
+	if called != 1 {
+		t.Errorf("Authorize called %d times, want 1", called)
+	}
+	if got := conn.Access(); got != "" {
+		t.Errorf("Access() = %q after rejection, want empty", got)
+	}
+	conn.mu.Lock()
+	failed, nonce := conn.verifyFailed, conn.nonce
+	conn.mu.Unlock()
+	if !failed {
+		t.Error("verifyFailed not set -- a rejected peer's channel would stay open")
+	}
+	if nonce != nil {
+		t.Error("nonce recorded for a rejected peer")
+	}
+}
+
+// TestReadOnlyShareRefusesControlCode models `share --read-only`: the
+// identity's own code exists (identities always carry one) but the
+// policy never grants control, so it is simply not a valid credential.
+func TestReadOnlyShareRefusesControlCode(t *testing.T) {
+	id, err := identity.Load("bitbang-authorize-readonly", true)
+	if err != nil {
+		t.Fatalf("identity: %v", err)
+	}
+	const viewCode = "VIEWONLY0001"
+	policy := func(code string) (protocol.Access, bool) {
+		if code == viewCode {
+			return protocol.AccessView, true
+		}
+		return "", false
+	}
+
+	conn, answerSDP := answeringPair(t, id)
+	conn.Authorize = policy
+	if err := conn.HandleAnswer(answerSDP, encryptedRequest(t, id, answerSDP, id.Code)); err == nil {
+		t.Fatal("read-only share accepted the identity's control code")
+	}
+
+	conn2, answerSDP2 := answeringPair(t, id)
+	conn2.Authorize = policy
+	if err := conn2.HandleAnswer(answerSDP2, encryptedRequest(t, id, answerSDP2, viewCode)); err != nil {
+		t.Fatalf("read-only share rejected its view code: %v", err)
+	}
+	if got := conn2.Access(); got != protocol.AccessView {
+		t.Errorf("Access() = %q, want view", got)
+	}
+}
+
+// TestNoAuthorizeKeepsDefaultCheck guards the unchanged path: without
+// a policy, HandleAnswer still compares against identity.Code.
+func TestNoAuthorizeKeepsDefaultCheck(t *testing.T) {
+	id, err := identity.Load("bitbang-authorize-default", true)
+	if err != nil {
+		t.Fatalf("identity: %v", err)
+	}
+
+	conn, answerSDP := answeringPair(t, id)
+	if err := conn.HandleAnswer(answerSDP, encryptedRequest(t, id, answerSDP, id.Code)); err != nil {
+		t.Fatalf("default path rejected the correct code: %v", err)
+	}
+	if got := conn.Access(); got != "" {
+		t.Errorf("Access() = %q with no policy, want empty", got)
+	}
+
+	conn2, answerSDP2 := answeringPair(t, id)
+	if err := conn2.HandleAnswer(answerSDP2, encryptedRequest(t, id, answerSDP2, "BADCODE0000")); err == nil {
+		t.Fatal("default path accepted a wrong code")
+	}
+}

--- a/internal/peer/close_test.go
+++ b/internal/peer/close_test.go
@@ -1,0 +1,85 @@
+package peer
+
+import (
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/pion/webrtc/v4"
+)
+
+// A peer abandoned before its data channel opens must still reach a terminal
+// PeerConnection state so listener cleanup has a reliable trigger.
+func TestDataChannelCloseDoesNotFireBeforeOpen(t *testing.T) {
+	pc, err := webrtc.NewPeerConnection(webrtc.Configuration{})
+	if err != nil {
+		t.Fatalf("new peer connection: %v", err)
+	}
+	dc, err := pc.CreateDataChannel("http", nil)
+	if err != nil {
+		t.Fatalf("create data channel: %v", err)
+	}
+
+	dcClosed := make(chan struct{})
+	dc.OnClose(func() { close(dcClosed) })
+	pcClosed := make(chan struct{})
+	var once atomic.Bool
+	pc.OnConnectionStateChange(func(s webrtc.PeerConnectionState) {
+		if s == webrtc.PeerConnectionStateClosed && once.CompareAndSwap(false, true) {
+			close(pcClosed)
+		}
+	})
+
+	offer, err := pc.CreateOffer(nil)
+	if err != nil {
+		t.Fatalf("create offer: %v", err)
+	}
+	if err := pc.SetLocalDescription(offer); err != nil {
+		t.Fatalf("set local description: %v", err)
+	}
+	// The connector never answers; we give up on it.
+	_ = pc.Close()
+
+	select {
+	case <-pcClosed:
+	case <-time.After(5 * time.Second):
+		t.Fatal("peer connection never reported a terminal state -- nothing left to hang teardown on")
+	}
+	select {
+	case <-dcClosed:
+		t.Log("note: pion now fires DataChannel.OnClose for a never-opened channel")
+	case <-time.After(500 * time.Millisecond):
+		// Expected: this is the gap the PC-state teardown covers.
+	}
+}
+
+func TestFireCloseRunsExactlyOnce(t *testing.T) {
+	var calls atomic.Int32
+	c := &Connection{}
+	c.SetOnClose(func() { calls.Add(1) })
+
+	c.fireClose()
+	c.fireClose()
+	c.fireClose()
+
+	if got := calls.Load(); got != 1 {
+		t.Errorf("OnClose ran %d times, want exactly 1", got)
+	}
+}
+
+func TestSetOnCloseAfterCloseRunsImmediately(t *testing.T) {
+	var calls atomic.Int32
+	c := &Connection{}
+	c.fireClose()
+	c.SetOnClose(func() { calls.Add(1) })
+	c.SetOnClose(func() { calls.Add(1) })
+
+	if got := calls.Load(); got != 1 {
+		t.Errorf("late OnClose ran %d times, want exactly 1", got)
+	}
+}
+
+func TestFireCloseWithoutCallback(t *testing.T) {
+	c := &Connection{}
+	c.fireClose()
+}

--- a/internal/peer/connection.go
+++ b/internal/peer/connection.go
@@ -21,12 +21,14 @@ import (
 	"fmt"
 	"log"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/pion/webrtc/v4"
 	"github.com/richlegrand/bitbang/internal/icehelper"
 	"github.com/richlegrand/bitbang/internal/identity"
 	"github.com/richlegrand/bitbang/internal/pairing"
+	"github.com/richlegrand/bitbang/internal/protocol"
 	"github.com/richlegrand/bitbang/internal/signaling"
 )
 
@@ -75,13 +77,6 @@ type Connection struct {
 	sig       *signaling.Client
 	OnMessage OnMessageFunc
 
-	// OnClose, if set, is invoked when the data channel transitions to
-	// closed. Used by listener wire-up to clean up per-session
-	// resources whose lifetime would otherwise outlast the connection
-	// — most importantly, kill any shell processes that would
-	// otherwise keep holding their max-sessions slot.
-	OnClose func()
-
 	// PairingMode is true when this connection was created by
 	// HandlePairRequest rather than HandleRequest. In pair mode the
 	// access-code check in HandleAnswer is skipped (the connector does not
@@ -89,6 +84,18 @@ type Connection struct {
 	// data-channel OnOpen runs the commitment + SAS confirmation flow
 	// (handlePairRequestOnOpen) instead of sending verify_nonce_hash.
 	PairingMode bool
+
+	// Authorize, if set, replaces HandleAnswer's default equality check
+	// against identity.Code: it classifies the presented access code into
+	// an access level ("" plus ok=false rejects). Listeners that issue
+	// more than one code per identity (bitbang share: control + view) set
+	// this after HandleRequest returns, before the answer arrives. Both
+	// run on the signaling read loop, so no lock is needed for the write.
+	// The granted level is readable via Access once HandleAnswer succeeds.
+	// Implementations must compare in constant time against every code
+	// they hold, without early exit, so timing doesn't reveal which role
+	// a guess missed.
+	Authorize func(code string) (access protocol.Access, ok bool)
 
 	// dcInbox carries inbound data-channel frames to the pairing handshake
 	// goroutine. Non-nil only in pair mode; the regular flow routes inbound
@@ -116,6 +123,59 @@ type Connection struct {
 	// this before sending the nonce-hash frame; on failure it closes the
 	// connection without sending anything.
 	verifyFailed bool
+	// access is the level granted by Authorize ("" when the default
+	// single-code check ran instead).
+	access protocol.Access
+
+	closeMu    sync.Mutex
+	closed     bool
+	onCloseSet bool
+	onClose    func()
+}
+
+// SetOnClose installs the connection teardown callback. If the connection
+// already closed, fn runs immediately. This makes callback installation safe
+// against a terminal WebRTC state racing listener setup.
+func (c *Connection) SetOnClose(fn func()) {
+	c.closeMu.Lock()
+	if c.onCloseSet {
+		c.closeMu.Unlock()
+		return
+	}
+	c.onCloseSet = true
+	if !c.closed {
+		c.onClose = fn
+		c.closeMu.Unlock()
+		return
+	}
+	c.closeMu.Unlock()
+	if fn != nil {
+		fn()
+	}
+}
+
+// fireClose runs the installed callback exactly once.
+func (c *Connection) fireClose() {
+	c.closeMu.Lock()
+	if c.closed {
+		c.closeMu.Unlock()
+		return
+	}
+	c.closed = true
+	fn := c.onClose
+	c.closeMu.Unlock()
+	if fn != nil {
+		fn()
+	}
+}
+
+// Access returns the access level granted by the Authorize hook, or "" when
+// the connection was verified by the default single-code check (or not yet
+// verified at all).
+func (c *Connection) Access() protocol.Access {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.access
 }
 
 // connSetup carries the per-flow customization for setupConnection:
@@ -210,17 +270,15 @@ func setupConnection(s connSetup) (*Connection, error) {
 		s.onOpen(conn, dc)
 	})
 
-	dcClosed := false
+	var dcClosed atomic.Bool
 	dc.OnClose(func() {
-		dcClosed = true
+		dcClosed.Store(true)
 		log.Printf("%s data channel closed for %s", s.logTag, s.clientID)
 		// Run caller-supplied cleanup BEFORE closing the PC, so any
 		// resources tied to the data channel (e.g. spawned shell
 		// processes) get torn down while the connection state is
 		// still observable.
-		if conn.OnClose != nil {
-			conn.OnClose()
-		}
+		conn.fireClose()
 		pc.Close()
 	})
 
@@ -240,7 +298,7 @@ func setupConnection(s connSetup) (*Connection, error) {
 	})
 
 	pc.OnConnectionStateChange(func(state webrtc.PeerConnectionState) {
-		if dcClosed {
+		if dcClosed.Load() {
 			return
 		}
 		if s.verbose {
@@ -249,7 +307,15 @@ func setupConnection(s connSetup) (*Connection, error) {
 		if state == webrtc.PeerConnectionStateConnected {
 			logSelectedPair(s.logTag, s.clientID, pc, time.Since(connStart))
 		}
-		if state == webrtc.PeerConnectionStateFailed {
+		// Failed and Closed are terminal, and a connector that dies
+		// before its data channel ever opens reaches them WITHOUT ever
+		// firing dc.OnClose (see
+		// TestDataChannelCloseDoesNotFireBeforeOpen). Teardown hung off
+		// the data channel alone would therefore never run, stranding
+		// whatever the listener reserved for this peer: a session slot,
+		// a share's controller or viewer slot.
+		if state == webrtc.PeerConnectionStateFailed || state == webrtc.PeerConnectionStateClosed {
+			conn.fireClose()
 			pc.Close()
 		}
 	})
@@ -372,7 +438,7 @@ func handleRequestOnOpen(conn *Connection, dc *webrtc.DataChannel) {
 	conn.mu.Unlock()
 	if failed {
 		log.Printf("Verify failed for %s — closing without nonce reply", conn.ClientID)
-		conn.PC.Close()
+		conn.Close()
 		return
 	}
 	if nonce == nil {
@@ -380,18 +446,18 @@ func handleRequestOnOpen(conn *Connection, dc *webrtc.DataChannel) {
 		// reject. Connecting clients must use a bootstrap that supports
 		// the encrypted_request field; older browsers won't be served.
 		log.Printf("No bidirectional-verify nonce for %s — closing", conn.ClientID)
-		conn.PC.Close()
+		conn.Close()
 		return
 	}
 	frame, err := buildVerifyNonceHashFrame(nonce)
 	if err != nil {
 		log.Printf("Build verify_nonce_hash for %s: %v", conn.ClientID, err)
-		conn.PC.Close()
+		conn.Close()
 		return
 	}
 	if err := dc.Send(frame); err != nil {
 		log.Printf("Send verify_nonce_hash for %s: %v", conn.ClientID, err)
-		conn.PC.Close()
+		conn.Close()
 		return
 	}
 }
@@ -448,8 +514,22 @@ func (c *Connection) HandleAnswer(sdp, encryptedRequestB64 string) error {
 
 	// Check the access code before anything else — a wrong code should
 	// never reveal whether the fingerprint matched. Constant-time compare
-	// to avoid leaking the code via timing.
-	if subtle.ConstantTimeCompare([]byte(req.Code), []byte(c.identity.Code)) != 1 {
+	// to avoid leaking the code via timing. An Authorize hook, when set,
+	// owns the comparison (and may grant one of several access levels).
+	if c.Authorize != nil {
+		access, ok := c.Authorize(req.Code)
+		if !ok {
+			c.markVerifyFailed()
+			ip := c.browserIP
+			if ip == "" {
+				ip = "?"
+			}
+			return fmt.Errorf("bad access code from %s (browser_ip=%s)", c.ClientID, ip)
+		}
+		c.mu.Lock()
+		c.access = access
+		c.mu.Unlock()
+	} else if subtle.ConstantTimeCompare([]byte(req.Code), []byte(c.identity.Code)) != 1 {
 		c.markVerifyFailed()
 		ip := c.browserIP
 		if ip == "" {
@@ -579,7 +659,7 @@ func handlePairRequestOnOpen(conn *Connection, prompt pairing.PromptFunc, id *id
 		// modern peer; if it does, refusing is the only safe move.
 		log.Printf("Pair %s: missing SDP fingerprints (local=%q remote=%q)", conn.ClientID, localFp, remoteFp)
 		conn.sendPairRejected("user_declined")
-		conn.PC.Close()
+		conn.Close()
 		return
 	}
 
@@ -588,13 +668,13 @@ func handlePairRequestOnOpen(conn *Connection, prompt pairing.PromptFunc, id *id
 	if !ok || pairing.PairMessageType(data) != pairing.MsgPairCommit {
 		log.Printf("Pair %s: no pair_commit", conn.ClientID)
 		conn.sendPairRejected("timeout")
-		conn.PC.Close()
+		conn.Close()
 		return
 	}
 	commit, ok := pairing.ParsePairCommit(data)
 	if !ok {
 		conn.sendPairRejected("user_declined")
-		conn.PC.Close()
+		conn.Close()
 		return
 	}
 
@@ -603,11 +683,11 @@ func handlePairRequestOnOpen(conn *Connection, prompt pairing.PromptFunc, id *id
 	if err != nil {
 		log.Printf("Pair %s: nonce: %v", conn.ClientID, err)
 		conn.sendPairRejected("user_declined")
-		conn.PC.Close()
+		conn.Close()
 		return
 	}
 	if err := conn.DC.Send(pairing.BuildPairChallenge(rd)); err != nil {
-		conn.PC.Close()
+		conn.Close()
 		return
 	}
 
@@ -616,14 +696,14 @@ func handlePairRequestOnOpen(conn *Connection, prompt pairing.PromptFunc, id *id
 	if !ok || pairing.PairMessageType(data) != pairing.MsgPairReveal {
 		log.Printf("Pair %s: no pair_reveal", conn.ClientID)
 		conn.sendPairRejected("timeout")
-		conn.PC.Close()
+		conn.Close()
 		return
 	}
 	rc, ok := pairing.ParsePairReveal(data)
 	if !ok || !pairing.VerifyCommitment(commit, rc) {
 		log.Printf("Pair %s: commitment did not open", conn.ClientID)
 		conn.sendPairRejected("sas_mismatch")
-		conn.PC.Close()
+		conn.Close()
 		return
 	}
 
@@ -636,7 +716,7 @@ func handlePairRequestOnOpen(conn *Connection, prompt pairing.PromptFunc, id *id
 	if !ok {
 		log.Printf("Pair rejected for %s: %s", conn.ClientID, reason)
 		conn.sendPairRejected(reason)
-		conn.PC.Close()
+		conn.Close()
 		return
 	}
 
@@ -652,7 +732,7 @@ func handlePairRequestOnOpen(conn *Connection, prompt pairing.PromptFunc, id *id
 	for i := 0; i < 200 && conn.DC.BufferedAmount() > 0; i++ {
 		time.Sleep(5 * time.Millisecond)
 	}
-	conn.PC.Close()
+	conn.Close()
 }
 
 // HandlePairAnswer applies the connector's SDP answer to a pair-flow peer
@@ -711,7 +791,8 @@ func (c *Connection) AddICECandidate(candidateData map[string]interface{}) error
 
 // Close closes the peer connection.
 func (c *Connection) Close() {
+	c.fireClose()
 	if c.PC != nil {
-		c.PC.Close()
+		_ = c.PC.Close()
 	}
 }

--- a/internal/protocol/swsp.go
+++ b/internal/protocol/swsp.go
@@ -42,6 +42,17 @@ const (
 	SWSPVersion = 3
 )
 
+// Access is the role granted to a peer during credential verification.
+// Empty access preserves the behavior of listeners with one undifferentiated
+// credential.
+type Access string
+
+const (
+	AccessDefault Access = ""
+	AccessControl Access = "control"
+	AccessView    Access = "view"
+)
+
 // Frame represents a single SWSP frame.
 type Frame struct {
 	StreamID uint32

--- a/internal/session/access_test.go
+++ b/internal/session/access_test.go
@@ -1,0 +1,76 @@
+package session
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/richlegrand/bitbang/internal/auth"
+	"github.com/richlegrand/bitbang/internal/protocol"
+	"github.com/richlegrand/bitbang/internal/streamtype"
+)
+
+// readySession drives a session through the stream-0 connect handshake
+// and returns the decoded `ready` message the listener emitted.
+func readySession(t *testing.T, access protocol.Access) map[string]interface{} {
+	t.Helper()
+	h := &countingHandler{}
+	sess := &Session{
+		PIN:           auth.New(""),
+		Access:        access,
+		handlers:      map[string]streamtype.StreamHandler{h.Type(): h},
+		streamHandler: make(map[uint32]streamtype.StreamHandler),
+		reasm:         make(map[uint32][]byte),
+	}
+
+	var readyPayload []byte
+	sess.sendFrame = func(streamID uint32, flags uint16, payload []byte) error {
+		if streamID == 0 {
+			var peek struct {
+				Type string `json:"type"`
+			}
+			_ = json.Unmarshal(payload, &peek)
+			if peek.Type == "ready" {
+				readyPayload = append([]byte(nil), payload...)
+			}
+		}
+		return nil
+	}
+
+	sess.HandleMessage(protocol.BuildFrame(0, protocol.FlagSYN,
+		[]byte(`{"type":"connect","path":"/","version":3}`)))
+
+	if readyPayload == nil {
+		t.Fatal("listener never sent a ready message")
+	}
+	var msg map[string]interface{}
+	if err := json.Unmarshal(readyPayload, &msg); err != nil {
+		t.Fatalf("ready is not valid JSON: %v", err)
+	}
+	return msg
+}
+
+func TestReadyCarriesAccessWhenSet(t *testing.T) {
+	for _, access := range []protocol.Access{protocol.AccessControl, protocol.AccessView} {
+		msg := readySession(t, access)
+		if got, _ := msg["access"].(string); got != string(access) {
+			t.Errorf("Access=%q: ready carried access=%q", access, got)
+		}
+		// The additive field must not disturb the existing contract.
+		if msg["type"] != "ready" || msg["routing"] != "target-prefix" {
+			t.Errorf("Access=%q: ready lost existing fields: %v", access, msg)
+		}
+		if _, ok := msg["caps"]; !ok {
+			t.Errorf("Access=%q: ready lost caps", access)
+		}
+	}
+}
+
+func TestReadyOmitsAccessWhenUnset(t *testing.T) {
+	msg := readySession(t, protocol.AccessDefault)
+	// Listeners without per-peer roles (serve shell/files/proxy) must
+	// emit exactly the pre-existing message -- an empty access string on
+	// the wire would be a new, meaningless value for clients to handle.
+	if _, present := msg["access"]; present {
+		t.Errorf("ready included an access field with no role set: %v", msg)
+	}
+}

--- a/internal/session/control.go
+++ b/internal/session/control.go
@@ -159,12 +159,18 @@ func (s *Session) sendReady() {
 	// cookies between different LAN hosts reached through the same UID;
 	// direct adapters (bitbang-python's WSGI/ASGI) declare "direct"
 	// instead, and everything under one UID shares a cookie jar.
-	ready, _ := json.Marshal(map[string]interface{}{
+	readyMsg := map[string]interface{}{
 		"type":           "ready",
 		"server_version": protocol.SWSPVersion,
 		"caps":           caps,
 		"routing":        "target-prefix",
-	})
+	}
+	// access is additive (like want_code on register): only present when
+	// the listener granted a per-peer role, and old clients ignore it.
+	if s.Access != "" {
+		readyMsg["access"] = s.Access
+	}
+	ready, _ := json.Marshal(readyMsg)
 	_ = s.sendFrame(0, protocol.FlagSYN|protocol.FlagFIN, ready)
 
 	// Channel is verified and ready — kick off the video PC handshake once.

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -27,6 +27,14 @@ type Session struct {
 	PIN     *auth.PINAuth
 	Verbose bool
 
+	// Access is the access level this peer was granted at answer
+	// verification time ("control" or "view" for bitbang share; "" for
+	// listeners without per-peer roles). Set once before the data channel
+	// opens, never after. Non-empty values are advertised additively on
+	// the `ready` message so clients can adapt (e.g. stop transmitting
+	// input in view mode); enforcement lives in the handlers, not here.
+	Access protocol.Access
+
 	// handlers is the set of registered StreamHandlers, keyed by their
 	// Type() string. Populated once at session creation; not modified
 	// after the data channel opens.

--- a/internal/share/capture_test.go
+++ b/internal/share/capture_test.go
@@ -1,0 +1,57 @@
+//go:build unix
+
+package share
+
+import (
+	"strings"
+	"sync"
+)
+
+// tmuxCapture is a streamtype.Stream that accumulates whatever a
+// handler writes, so the integration tests can assert on what an
+// attached tmux client actually rendered.
+type tmuxCapture struct {
+	mu  sync.Mutex
+	out []byte
+}
+
+func newTmuxCapture() *tmuxCapture { return &tmuxCapture{} }
+
+func (c *tmuxCapture) ID() uint32              { return 1 }
+func (c *tmuxCapture) ConnectPath() string     { return "/" }
+func (c *tmuxCapture) WriteSYN(p []byte) error { return nil }
+func (c *tmuxCapture) WriteDAT(p []byte) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	// Frames are [tag][payload]; the tests only care about output text.
+	if len(p) > 1 {
+		c.out = append(c.out, p[1:]...)
+	}
+	return nil
+}
+func (c *tmuxCapture) WriteFIN(p []byte) error          { return nil }
+func (c *tmuxCapture) SendRaw(_ uint16, p []byte) error { return c.WriteDAT(p) }
+func (c *tmuxCapture) BufferedAmount() uint64           { return 0 }
+
+// text returns everything written so far, with ANSI escape sequences
+// stripped so assertions can match plain content.
+func (c *tmuxCapture) text() string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	s := string(c.out)
+	var b strings.Builder
+	for i := 0; i < len(s); {
+		if s[i] == 0x1b {
+			// Skip CSI/OSC/two-byte escapes up to a plausible terminator.
+			j := i + 1
+			for j < len(s) && !strings.ContainsRune("@ABCDEFGHJKSTfhilmnprstu\x07", rune(s[j])) {
+				j++
+			}
+			i = j + 1
+			continue
+		}
+		b.WriteByte(s[i])
+		i++
+	}
+	return b.String()
+}

--- a/internal/share/lock_other.go
+++ b/internal/share/lock_other.go
@@ -1,0 +1,19 @@
+//go:build !unix
+
+package share
+
+import "errors"
+
+// ErrLockBusy means another process holds a target's lifecycle lock.
+var ErrLockBusy = errors.New("share lifecycle lock is held")
+
+var errLockUnsupported = errors.New("share lifecycle locks are unavailable on this platform")
+
+// Lock is the platform-specific share lifecycle lock.
+type Lock struct{}
+
+// TryLock reports that share hosting is unavailable on this platform.
+func TryLock(path string) (*Lock, int, error) { return nil, 0, errLockUnsupported }
+
+// Release is a no-op because TryLock cannot succeed on this platform.
+func (l *Lock) Release() {}

--- a/internal/share/lock_unix.go
+++ b/internal/share/lock_unix.go
@@ -1,0 +1,70 @@
+//go:build unix
+
+package share
+
+import (
+	"errors"
+	"os"
+	"strconv"
+	"strings"
+	"syscall"
+)
+
+// ErrLockBusy means another process holds a target's lifecycle lock.
+var ErrLockBusy = errors.New("share lifecycle lock is held")
+
+// Lock is an advisory flock over one share target, held for as long as
+// a decision about that target is being acted on.
+//
+// The kernel drops it when the holder exits, so a crash never leaves it
+// stale, and it is taken on a path beside the state directory -- see
+// LockPathFor -- because cleanup deletes that directory, and a lock file
+// that gets deleted excludes nobody.
+//
+// The PID in the file is only there to name the holder in a message.
+// The flock is what excludes; nothing decides anything from the PID.
+type Lock struct{ f *os.File }
+
+// TryLock takes the lock without waiting. It returns ErrLockBusy and
+// the holder's PID (0 if unreadable) when someone else has it, and any
+// other error as itself -- a lock file that cannot be opened is a
+// different problem from a lock that is held, and reporting the first
+// as the second sends the operator looking for a process that does not
+// exist.
+func TryLock(path string) (*Lock, int, error) {
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		return nil, 0, err
+	}
+	if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); err != nil {
+		if errors.Is(err, syscall.EWOULDBLOCK) || errors.Is(err, syscall.EAGAIN) {
+			pid := readLockHolder(f)
+			_ = f.Close()
+			return nil, pid, ErrLockBusy
+		}
+		_ = f.Close()
+		return nil, 0, err
+	}
+	// We hold it: replace any stale PID with our own. Best-effort -- the
+	// lock is valid regardless of what the file says.
+	if err := f.Truncate(0); err == nil {
+		_, _ = f.WriteAt([]byte(strconv.Itoa(os.Getpid())+"\n"), 0)
+	}
+	return &Lock{f: f}, 0, nil
+}
+
+func readLockHolder(f *os.File) int {
+	buf := make([]byte, 32)
+	n, _ := f.ReadAt(buf, 0)
+	pid, _ := strconv.Atoi(strings.TrimSpace(string(buf[:n])))
+	return pid
+}
+
+// Release drops the lock. Safe on a nil Lock.
+func (l *Lock) Release() {
+	if l == nil || l.f == nil {
+		return
+	}
+	_ = syscall.Flock(int(l.f.Fd()), syscall.LOCK_UN)
+	_ = l.f.Close()
+}

--- a/internal/share/share_test.go
+++ b/internal/share/share_test.go
@@ -1,0 +1,506 @@
+package share
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+)
+
+// fakeRunner records the tmux command lines it is asked to run and
+// replays canned responses, so share's control flow can be exercised
+// without a tmux server.
+type fakeRunner struct {
+	socket  string
+	calls   [][]string
+	replies map[string]string
+	errs    map[string]error
+}
+
+func newFakeRunner() *fakeRunner {
+	return &fakeRunner{replies: map[string]string{}, errs: map[string]error{}}
+}
+
+func (f *fakeRunner) Socket() string { return f.socket }
+
+func (f *fakeRunner) Run(args ...string) (string, error) {
+	f.calls = append(f.calls, args)
+	key := args[0]
+	if err, ok := f.errs[key]; ok {
+		return "", err
+	}
+	return f.replies[key], nil
+}
+
+func TestCheckVersion(t *testing.T) {
+	tests := []struct {
+		version string
+		wantErr bool
+	}{
+		{"tmux 3.2", false},
+		{"tmux 3.2a", false},
+		{"tmux 3.4", false},
+		{"tmux 4.0", false},
+		{"tmux 10.1", false},
+		{"tmux 3.1b", true},
+		{"tmux 2.8", true},
+		{"tmux next-3.6", false}, // parses as 3.6
+		{"tmux master", false},   // unparseable -> assume new enough
+	}
+	for _, tc := range tests {
+		r := newFakeRunner()
+		r.replies["-V"] = tc.version
+		err := CheckVersion(r)
+		if tc.wantErr && err == nil {
+			t.Errorf("CheckVersion(%q): got nil, want error", tc.version)
+		}
+		if !tc.wantErr && err != nil {
+			t.Errorf("CheckVersion(%q): got %v, want nil", tc.version, err)
+		}
+	}
+}
+
+func TestCheckVersionPropagatesRunError(t *testing.T) {
+	r := newFakeRunner()
+	r.errs["-V"] = errors.New("no server running")
+	if err := CheckVersion(r); err == nil {
+		t.Fatal("got nil error, want the runner's error")
+	}
+}
+
+func TestSocketFromEnv(t *testing.T) {
+	t.Setenv("TMUX", "/tmp/tmux-501/default,12345,0")
+	if got := SocketFromEnv(); got != "/tmp/tmux-501/default" {
+		t.Errorf("got %q, want the socket path", got)
+	}
+	t.Setenv("TMUX", "")
+	if got := SocketFromEnv(); got != "" {
+		t.Errorf("outside tmux: got %q, want empty", got)
+	}
+}
+
+func TestDiscoverInsideTmux(t *testing.T) {
+	t.Setenv("TMUX", "/tmp/sock,1,0")
+	r := newFakeRunner()
+	r.replies["display-message"] = "$4\twork\t/tmp/sock"
+
+	tgt, err := Discover(r, "")
+	if err != nil {
+		t.Fatalf("Discover: %v", err)
+	}
+	if tgt.SessionID != "$4" || tgt.SessionName != "work" {
+		t.Errorf("got %+v, want session $4 named work", tgt)
+	}
+	// Without an explicit target, the pane must be resolved from the
+	// environment -- passing -t would target the wrong session.
+	for _, a := range r.calls[0] {
+		if a == "-t" {
+			t.Error("Discover with no --target passed -t to tmux")
+		}
+	}
+}
+
+func TestDiscoverOutsideTmuxRequiresTarget(t *testing.T) {
+	t.Setenv("TMUX", "")
+	r := newFakeRunner()
+	if _, err := Discover(r, ""); err == nil {
+		t.Fatal("got nil error, want a demand for --target")
+	}
+	if len(r.calls) != 0 {
+		t.Errorf("ran tmux %v before failing; should fail without invoking tmux", r.calls)
+	}
+
+	r.replies["display-message"] = "$7\tother\t/tmp/sock"
+	tgt, err := Discover(r, "other")
+	if err != nil {
+		t.Fatalf("Discover with explicit target: %v", err)
+	}
+	if tgt.SessionID != "$7" {
+		t.Errorf("got session %q, want $7", tgt.SessionID)
+	}
+}
+
+// TestDiscoverUsesServerReportedSocket: a share is keyed on the socket
+// path, and one server answers to several spellings. Taking tmux's own
+// answer is what stops `share status` from outside tmux keying a
+// different share than `share` did from inside it.
+func TestDiscoverUsesServerReportedSocket(t *testing.T) {
+	t.Setenv("TMUX", "/tmp/sock,1,0")
+	r := newFakeRunner()
+	r.socket = "" // reached via tmux's default socket
+	r.replies["display-message"] = "$4\twork\t/private/tmp/tmux-501/default"
+
+	tgt, err := Discover(r, "")
+	if err != nil {
+		t.Fatalf("Discover: %v", err)
+	}
+	if tgt.Socket != "/private/tmp/tmux-501/default" {
+		t.Errorf("Socket = %q, want the path tmux reported", tgt.Socket)
+	}
+}
+
+// TestDiscoverRefusesForeignSocketWithoutTarget: with --socket pointing
+// at another server and no --target, display-message would resolve that
+// server's current session -- publishing, read-write, a session the user
+// is not looking at.
+func TestDiscoverRefusesForeignSocketWithoutTarget(t *testing.T) {
+	t.Setenv("TMUX", "/tmp/serverA,1,0")
+	r := newFakeRunner()
+	r.socket = "/tmp/serverB"
+	r.replies["display-message"] = "$9\tsomething-else\t/tmp/serverB"
+
+	if _, err := Discover(r, ""); err == nil {
+		t.Fatal("Discover resolved against a different server than the caller is in")
+	}
+	// With an explicit target the user has said which session they mean.
+	if _, err := Discover(r, "other"); err != nil {
+		t.Errorf("Discover with an explicit target: %v", err)
+	}
+}
+
+func TestDiscoverRejectsUnparseableOutput(t *testing.T) {
+	t.Setenv("TMUX", "/tmp/sock,1,0")
+	r := newFakeRunner()
+	r.replies["display-message"] = "no session id here"
+	if _, err := Discover(r, ""); err == nil {
+		t.Fatal("got nil error, want rejection of output without a $id")
+	}
+}
+
+func TestAttachEnvStripsTmuxVars(t *testing.T) {
+	in := []string{
+		"PATH=/usr/bin",
+		"TMUX=/tmp/sock,1,0",
+		"TMUX_PANE=%3",
+		"TERM=screen-256color",
+		"HOME=/home/x",
+	}
+	got := AttachEnv(in)
+	for _, kv := range got {
+		if strings.HasPrefix(kv, "TMUX=") || strings.HasPrefix(kv, "TMUX_PANE=") {
+			t.Errorf("AttachEnv kept %q -- tmux refuses to attach with $TMUX set", kv)
+		}
+	}
+	if !contains(got, "TERM=screen-256color") {
+		t.Error("AttachEnv dropped an existing TERM")
+	}
+	if !contains(got, "PATH=/usr/bin") || !contains(got, "HOME=/home/x") {
+		t.Errorf("AttachEnv dropped unrelated variables: %v", got)
+	}
+}
+
+// TestAttachEnvReplacesUnusableTerm: tmux refuses to attach under a
+// capability-free TERM, so passing one through means every peer's
+// attach exits the moment it starts.
+func TestAttachEnvReplacesUnusableTerm(t *testing.T) {
+	for _, bad := range []string{"dumb", "unknown", ""} {
+		got := AttachEnv([]string{"PATH=/usr/bin", "TERM=" + bad})
+		if !contains(got, "TERM=xterm-256color") {
+			t.Errorf("TERM=%q: got %v, want the default substituted", bad, got)
+		}
+		if bad != "" && contains(got, "TERM="+bad) {
+			t.Errorf("TERM=%q was passed through; tmux cannot attach under it", bad)
+		}
+	}
+	// A usable TERM is still the operator's to choose.
+	got := AttachEnv([]string{"TERM=screen-256color"})
+	if !contains(got, "TERM=screen-256color") {
+		t.Errorf("got %v, want a usable TERM preserved", got)
+	}
+}
+
+func TestAttachEnvDefaultsTerm(t *testing.T) {
+	got := AttachEnv([]string{"PATH=/usr/bin"})
+	if !contains(got, "TERM=xterm-256color") {
+		t.Errorf("got %v, want a defaulted TERM", got)
+	}
+	// An empty TERM is as useless as a missing one.
+	got = AttachEnv([]string{"TERM="})
+	if !contains(got, "TERM=xterm-256color") {
+		t.Errorf("got %v, want empty TERM replaced", got)
+	}
+	if contains(got, "TERM=") {
+		t.Errorf("got %v, want the empty TERM removed", got)
+	}
+}
+
+func contains(hay []string, needle string) bool {
+	for _, s := range hay {
+		if s == needle {
+			return true
+		}
+	}
+	return false
+}
+
+func TestShellQuote(t *testing.T) {
+	tests := map[string]string{
+		"":                    "''",
+		"plain":               "'plain'",
+		"/path/with space":    "'/path/with space'",
+		"it's":                `'it'\''s'`,
+		"; rm -rf /":          "'; rm -rf /'",
+		"$(whoami)":           "'$(whoami)'",
+		"`id`":                "'`id`'",
+		"a'; touch /tmp/x; '": `'a'\''; touch /tmp/x; '\'''`,
+	}
+	for in, want := range tests {
+		if got := ShellQuote(in); got != want {
+			t.Errorf("ShellQuote(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestTargetHashDistinguishesSocketAndSession(t *testing.T) {
+	a := TargetHash("/tmp/a", "$1")
+	b := TargetHash("/tmp/a", "$2")
+	c := TargetHash("/tmp/b", "$1")
+	if a == b || a == c || b == c {
+		t.Errorf("hashes collide: %q %q %q", a, b, c)
+	}
+	if a != TargetHash("/tmp/a", "$1") {
+		t.Error("TargetHash is not stable across calls")
+	}
+	// Must be usable as a directory and tmux session-name component.
+	if strings.ContainsAny(a, "/. \t") {
+		t.Errorf("hash %q contains characters unsafe for paths/session names", a)
+	}
+	if len(a) != 24 {
+		t.Errorf("hash length = %d, want 24 hex characters", len(a))
+	}
+}
+
+func TestStateRoundTripAndPermissions(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "shares", "abc123")
+	want := &State{
+		Socket:      "/tmp/sock",
+		SessionID:   "$2",
+		SessionName: "work",
+		MgmtSession: "_bbshare_abc123",
+		UID:         "uid-xyz",
+		Server:      "bitba.ng",
+		ControlURL:  "https://bitba.ng/uid-xyz#ctrl!ephemeral",
+		ViewURL:     "https://bitba.ng/uid-xyz#view!ephemeral",
+		MaxViewers:  16,
+		CreatedAt:   time.Now().Truncate(time.Second),
+		ExpiresAt:   time.Now().Add(time.Hour).Truncate(time.Second),
+		TTLSeconds:  3600,
+	}
+	if err := SaveState(dir, want); err != nil {
+		t.Fatalf("SaveState: %v", err)
+	}
+
+	if runtime.GOOS != "windows" {
+		fi, err := os.Stat(filepath.Join(dir, "state.json"))
+		if err != nil {
+			t.Fatalf("stat: %v", err)
+		}
+		if perm := fi.Mode().Perm(); perm != 0o600 {
+			t.Errorf("state.json mode = %o, want 600", perm)
+		}
+		di, err := os.Stat(dir)
+		if err != nil {
+			t.Fatalf("stat dir: %v", err)
+		}
+		if perm := di.Mode().Perm(); perm != 0o700 {
+			t.Errorf("state dir mode = %o, want 700", perm)
+		}
+	}
+
+	got, err := LoadState(dir)
+	if err != nil {
+		t.Fatalf("LoadState: %v", err)
+	}
+	if got.ControlURL != want.ControlURL || got.ViewURL != want.ViewURL ||
+		got.SessionID != want.SessionID || got.MaxViewers != want.MaxViewers ||
+		got.TTLSeconds != want.TTLSeconds {
+		t.Errorf("round trip mismatch:\n got %+v\nwant %+v", got, want)
+	}
+	if !got.ExpiresAt.Equal(want.ExpiresAt) {
+		t.Errorf("ExpiresAt: got %v, want %v", got.ExpiresAt, want.ExpiresAt)
+	}
+
+	// No leftover temp file from the atomic write.
+	if matches, err := filepath.Glob(filepath.Join(dir, ".state-*.tmp")); err != nil || len(matches) != 0 {
+		t.Errorf("temporary state files remain after SaveState: %v (glob error: %v)", matches, err)
+	}
+}
+
+func TestLoadStateMissingAndCorrupt(t *testing.T) {
+	dir := t.TempDir()
+	st, err := LoadState(dir)
+	if err != nil || st != nil {
+		t.Fatalf("missing state: got (%v, %v), want (nil, nil)", st, err)
+	}
+
+	if err := os.WriteFile(filepath.Join(dir, "state.json"), []byte("{not json"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := LoadState(dir); err == nil {
+		t.Fatal("corrupt state: got nil error, want a parse failure so callers clean it up")
+	}
+}
+
+func TestSaveStateOverwrites(t *testing.T) {
+	dir := t.TempDir()
+	if err := SaveState(dir, &State{ViewURL: "first", SessionID: "$1"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := SaveState(dir, &State{ViewURL: "second", SessionID: "$1"}); err != nil {
+		t.Fatal(err)
+	}
+	got, err := LoadState(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.ViewURL != "second" {
+		t.Errorf("got %q, want the second write to win", got.ViewURL)
+	}
+}
+
+func TestRemoveState(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "s")
+	if err := SaveState(dir, &State{ViewURL: "u", SessionID: "$1"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := RemoveState(dir); err != nil {
+		t.Fatalf("RemoveState: %v", err)
+	}
+	if _, err := os.Stat(dir); !os.IsNotExist(err) {
+		t.Error("state directory survived RemoveState")
+	}
+	// Removing a share that was never started must not error.
+	if err := RemoveState(dir); err != nil {
+		t.Errorf("second RemoveState: %v", err)
+	}
+}
+
+func TestNewAccessCodeShape(t *testing.T) {
+	seen := map[string]bool{}
+	for i := 0; i < 50; i++ {
+		code, err := NewAccessCode()
+		if err != nil {
+			t.Fatalf("NewAccessCode: %v", err)
+		}
+		// 8 random bytes, base64url, no padding -- same shape as an
+		// identity access code.
+		if len(code) != 11 {
+			t.Fatalf("code %q has length %d, want 11", code, len(code))
+		}
+		if strings.ContainsAny(code, "+/=") {
+			t.Fatalf("code %q is not URL-safe base64", code)
+		}
+		if seen[code] {
+			t.Fatalf("duplicate code %q across draws", code)
+		}
+		seen[code] = true
+	}
+}
+
+// TestPrepareDirRefusesUnwritable: the parent establishes the state
+// directory precisely so an unwritable one is reported by something
+// that can still speak. A worker that discovers it has nowhere to write
+// its last words has nowhere to write them.
+func TestPrepareDirRefusesUnwritable(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows does not enforce Unix mode bits")
+	}
+	if os.Getuid() == 0 {
+		t.Skip("root writes through any mode")
+	}
+	parent := t.TempDir()
+	dir := filepath.Join(parent, "shares")
+	if err := os.Mkdir(dir, 0o500); err != nil {
+		t.Fatal(err)
+	}
+
+	// MkdirAll alone is satisfied here -- the directory exists. Only
+	// trying to write says otherwise.
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatalf("precondition: MkdirAll should succeed on an existing dir: %v", err)
+	}
+	if err := PrepareDir(dir); err == nil {
+		t.Error("PrepareDir accepted a directory it cannot write to")
+	}
+}
+
+func TestPrepareDirCreatesAndLeavesNothing(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "a", "b")
+	if err := PrepareDir(dir); err != nil {
+		t.Fatalf("PrepareDir: %v", err)
+	}
+	info, err := os.Stat(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if runtime.GOOS != "windows" && info.Mode().Perm() != 0o700 {
+		perm := info.Mode().Perm()
+		t.Errorf("mode = %o, want 700 for a directory holding credentials", perm)
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 0 {
+		t.Errorf("PrepareDir left %d files behind; the write probe must clean up", len(entries))
+	}
+}
+
+// TestStartupErrorRoundTrip: a worker that dies before it can serve
+// takes its pane with it, so this file is the only copy of why.
+func TestStartupErrorRoundTrip(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "state")
+
+	if got := TakeStartupError(dir, "n1"); got != "" {
+		t.Errorf("TakeStartupError on a missing directory = %q, want empty", got)
+	}
+
+	SaveStartupError(dir, "n1", "dial bitba.ng: no such host\n")
+	got := TakeStartupError(dir, "n1")
+	if got != "dial bitba.ng: no such host" {
+		t.Errorf("TakeStartupError = %q, want the worker's message, trimmed", got)
+	}
+
+	// Taken means taken: a later failure must not be explained by an
+	// earlier one's leftovers.
+	if again := TakeStartupError(dir, "n1"); again != "" {
+		t.Errorf("TakeStartupError left %q behind for the next start to misreport", again)
+	}
+}
+
+// TestStartupErrorIsScopedToItsStart: the file has one name per target,
+// so a worker whose parent was killed before reading it leaves its
+// explanation where the next start would find it. Reporting another
+// attempt's failure as your own sends the operator after the wrong
+// thing entirely.
+func TestStartupErrorIsScopedToItsStart(t *testing.T) {
+	dir := t.TempDir()
+	SaveStartupError(dir, "an-older-start", "the reason that start failed")
+
+	if got := TakeStartupError(dir, "this-start"); got != "" {
+		t.Errorf("TakeStartupError = %q, which belongs to a different start", got)
+	}
+	// Removed all the same, or it waits for the start whose nonce it
+	// happens to match -- which is never.
+	if _, err := os.Stat(filepath.Join(dir, "startup-error")); !os.IsNotExist(err) {
+		t.Error("a foreign startup error was left behind to accumulate")
+	}
+}
+
+// TestSaveStartupErrorPermissions: the message can name a hostname or a
+// path, and it sits in the same directory as the credential file.
+func TestSaveStartupErrorPermissions(t *testing.T) {
+	dir := t.TempDir()
+	SaveStartupError(dir, "n1", "boom")
+	info, err := os.Stat(filepath.Join(dir, "startup-error"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if runtime.GOOS != "windows" && info.Mode().Perm() != 0o600 {
+		perm := info.Mode().Perm()
+		t.Errorf("mode = %o, want 600", perm)
+	}
+}

--- a/internal/share/state.go
+++ b/internal/share/state.go
@@ -1,0 +1,231 @@
+package share
+
+import (
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// State is the on-disk record of a running share. The worker writes it
+// after signaling registration succeeds, and a later share command removes
+// it under the target lifecycle lock. It contains bearer credentials and is
+// stored under ~/.bitbang/shares with 0700 directory and 0600 file modes.
+type State struct {
+	Socket      string `json:"socket,omitempty"`
+	SessionID   string `json:"session_id"`
+	SessionName string `json:"session_name,omitempty"`
+	MgmtSession string `json:"mgmt_session"`
+	UID         string `json:"uid"`
+	Server      string `json:"server"`
+
+	// ControlURL is absent for --read-only shares: the control
+	// credential is never generated, so a broadcast share physically
+	// cannot be typed into.
+	ControlURL string `json:"control_url,omitempty"`
+	ViewURL    string `json:"view_url"`
+	MaxViewers int    `json:"max_viewers"`
+
+	// Nonce identifies the attempt to start a share that produced this
+	// state. The parent generates one per `bitbang share`, hands it to
+	// the worker, and accepts back only state carrying it -- otherwise a
+	// file left behind by a worker that was killed reads as the new
+	// one's, and a dead share's URLs get printed as live.
+	Nonce string `json:"nonce,omitempty"`
+
+	CreatedAt time.Time `json:"created_at"`
+	// ExpiresAt zero means "until stopped" (--ttl 0).
+	ExpiresAt time.Time `json:"expires_at,omitzero"`
+	// TTLSeconds is the lifetime the share was started with (0 = until
+	// stopped). Kept alongside ExpiresAt so re-running `share` can tell
+	// a matching request from a changed one without doing arithmetic on
+	// a clock that has since moved.
+	TTLSeconds int `json:"ttl_seconds"`
+}
+
+// BaseDir is where per-share state directories live.
+func BaseDir() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, ".bitbang", "shares"), nil
+}
+
+// Dir returns the state directory for a target hash.
+func Dir(hash string) (string, error) {
+	base, err := BaseDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(base, hash), nil
+}
+
+// LockPathFor returns the lifecycle lock beside a target's state
+// directory.
+//
+// Beside it, not inside it: cleanup removes that directory while the
+// lock is held, and a lock file that gets deleted excludes nobody -- the
+// next process creates a fresh file at the same path and locks that
+// instead. Naming it from the directory is what lets the sweep, which
+// finds targets by reading the directory listing, lock each one without
+// having to recompute a hash it never saw.
+func LockPathFor(stateDir string) string { return stateDir + ".lock" }
+
+// LockPath returns the lifecycle lock for a target hash.
+func LockPath(hash string) (string, error) {
+	dir, err := Dir(hash)
+	if err != nil {
+		return "", err
+	}
+	return LockPathFor(dir), nil
+}
+
+// TargetHash derives the stable directory / management-session key for
+// a share target from the tmux socket and session ID.
+func TargetHash(socket, sessionID string) string {
+	sum := sha256.Sum256([]byte(socket + "\x00" + sessionID))
+	return hex.EncodeToString(sum[:12])
+}
+
+// PrepareDir creates a share's state directory and proves it is
+// writable.
+//
+// A worker's last words go in this directory (see SaveStartupError),
+// which makes an unwritable one the one failure it cannot report on its
+// own -- a read-only home, a full disk, a mode nobody meant to set. Its
+// pane dies with it and takes the log too. Establishing the directory
+// in the parent moves that whole class somewhere it can still be said
+// out loud, before any worker is spawned to fail silently.
+func PrepareDir(dir string) error {
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return err
+	}
+	// MkdirAll is satisfied by a directory that already exists with a
+	// mode that forbids writing to it, so ask for what is actually
+	// needed rather than for its name.
+	f, err := os.CreateTemp(dir, ".probe-*")
+	if err != nil {
+		return err
+	}
+	name := f.Name()
+	_ = f.Close()
+	return os.Remove(name)
+}
+
+const stateFile = "state.json"
+
+// startupErrorFile holds a worker's last words when it dies before it
+// can serve. Its pane goes with it, so this is the only place the
+// parent can still read them from.
+const startupErrorFile = "startup-error"
+
+// SaveStartupError records why a worker gave up, stamped with the nonce
+// of the start it belongs to. Best-effort: the caller is already failing
+// and has nothing better to do with a second error.
+func SaveStartupError(dir, nonce, msg string) {
+	if dir == "" || msg == "" {
+		return
+	}
+	_ = os.MkdirAll(dir, 0o700)
+	_ = os.WriteFile(filepath.Join(dir, startupErrorFile), []byte(nonce+"\n"+msg), 0o600)
+}
+
+// TakeStartupError removes any recorded startup error and returns it
+// only when it belongs to this start.
+//
+// The file has one name per target, so a worker whose parent was killed
+// before it could read the file leaves its explanation lying where the
+// next start would find it and report it as its own. The nonce is what
+// makes that impossible; removing it either way is what stops it
+// accumulating.
+func TakeStartupError(dir, nonce string) string {
+	path := filepath.Join(dir, startupErrorFile)
+	data, err := os.ReadFile(path)
+	_ = os.Remove(path)
+	if err != nil {
+		return ""
+	}
+	stamp, msg, ok := strings.Cut(string(data), "\n")
+	if !ok || stamp != nonce {
+		return ""
+	}
+	return strings.TrimSpace(msg)
+}
+
+// LoadState reads a share's state. Returns (nil, nil) when no state
+// exists; a non-nil error means the file exists but can't be parsed
+// (callers treat that as stale and clean it up).
+func LoadState(dir string) (*State, error) {
+	data, err := os.ReadFile(filepath.Join(dir, stateFile))
+	if errors.Is(err, fs.ErrNotExist) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	var st State
+	if err := json.Unmarshal(data, &st); err != nil {
+		return nil, fmt.Errorf("corrupt share state: %w", err)
+	}
+	return &st, nil
+}
+
+// SaveState writes the state atomically with credential-grade permissions.
+func SaveState(dir string, st *State) error {
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return err
+	}
+	out, err := json.MarshalIndent(st, "", "  ")
+	if err != nil {
+		return err
+	}
+	path := filepath.Join(dir, stateFile)
+	tmp, err := os.CreateTemp(dir, ".state-*.tmp")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	defer os.Remove(tmpName)
+	if err := tmp.Chmod(0o600); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if _, err := tmp.Write(out); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	return os.Rename(tmpName, path)
+}
+
+// RemoveState deletes a share's state directory.
+func RemoveState(dir string) error {
+	return os.RemoveAll(dir)
+}
+
+// NewNonce returns a value naming one attempt to start a share. Same
+// shape as an access code and generated the same way, but it authorises
+// nothing: it travels on the worker's command line, where anyone who
+// could read it could already read the state file it protects.
+func NewNonce() (string, error) { return NewAccessCode() }
+
+// NewAccessCode returns a fresh 64-bit access code in the same shape
+// as identity access codes: 8 random bytes, base64url, 11 characters.
+func NewAccessCode() (string, error) {
+	var b [8]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return "", err
+	}
+	return base64.RawURLEncoding.EncodeToString(b[:]), nil
+}

--- a/internal/share/testutil_test.go
+++ b/internal/share/testutil_test.go
@@ -1,0 +1,18 @@
+package share
+
+import (
+	"testing"
+	"time"
+)
+
+func waitFor(t *testing.T, what string, cond func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(10 * time.Second)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for %s", what)
+}

--- a/internal/share/tmux.go
+++ b/internal/share/tmux.go
@@ -1,0 +1,260 @@
+// Package share implements the tmux plumbing and on-disk state behind
+// `bitbang share` -- publishing a running tmux session as a URL.
+//
+// The CLI never speaks the tmux protocol: tmux is driven exclusively
+// through its command-line interface (via Runner), used both as the
+// thing being shared (role-scoped `attach-session` commands run under
+// forced argv) and as the background supervisor (a detached management
+// session hosts the share worker, so no PID files or setsid are needed).
+package share
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// Runner executes tmux commands. An interface so share's control flow
+// (discovery, supervision, cleanup) is testable against a fake tmux.
+type Runner interface {
+	// Run executes tmux with the given arguments (after any -S socket
+	// preamble) and returns trimmed stdout. A non-zero exit becomes an
+	// error carrying tmux's stderr.
+	Run(args ...string) (string, error)
+	// Socket reports the -S path this runner was built with, or "" for
+	// tmux's default socket. Discover compares it against the caller's
+	// enclosing server.
+	Socket() string
+}
+
+// ExecRunner runs the real tmux binary.
+type ExecRunner struct {
+	Bin  string // tmux binary; "tmux" resolves via PATH
+	Sock string // -S socket path; empty = tmux's default socket
+
+	// Timeout bounds one invocation. Zero waits indefinitely, which is
+	// right for the server the operator asked about -- they would rather
+	// wait than be told a wrong answer quickly. It is wrong for a
+	// server reached incidentally, which is what the share sweep does:
+	// a tmux client that connects and never gets a reply hangs, and a
+	// hang there would be attributed to whatever command was running.
+	Timeout time.Duration
+}
+
+// NewRunner returns an ExecRunner bound to the given server socket
+// ("" = tmux's default socket for this user).
+func NewRunner(socket string) *ExecRunner {
+	return &ExecRunner{Bin: "tmux", Sock: socket}
+}
+
+// Socket implements Runner.
+func (r *ExecRunner) Socket() string { return r.Sock }
+
+func (r *ExecRunner) Run(args ...string) (string, error) {
+	full := make([]string, 0, len(args)+2)
+	if r.Sock != "" {
+		full = append(full, "-S", r.Sock)
+	}
+	full = append(full, args...)
+	ctx := context.Background()
+	if r.Timeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, r.Timeout)
+		defer cancel()
+	}
+	cmd := exec.CommandContext(ctx, r.Bin, full...)
+	// A newly forked tmux server can inherit the command's output pipes.
+	// WaitDelay bounds Wait after the context kills the client process.
+	cmd.WaitDelay = r.Timeout
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		msg := strings.TrimSpace(stderr.String())
+		if msg == "" {
+			msg = err.Error()
+		}
+		return "", fmt.Errorf("tmux %s: %s", args[0], msg)
+	}
+	return strings.TrimSpace(stdout.String()), nil
+}
+
+// Target identifies the tmux session being shared.
+type Target struct {
+	Socket      string // tmux server socket path ("" = default socket)
+	SessionID   string // stable tmux session ID, e.g. "$3"
+	SessionName string // display name at share time (may be renamed later)
+}
+
+// SocketFromEnv returns the socket path of the enclosing tmux server,
+// or "" when not running inside tmux. $TMUX is "socket,pid,paneidx".
+func SocketFromEnv() string {
+	env := os.Getenv("TMUX")
+	if env == "" {
+		return ""
+	}
+	if i := strings.IndexByte(env, ','); i > 0 {
+		return env[:i]
+	}
+	return ""
+}
+
+// Discover resolves the session to share. targetFlag names a session
+// (name or $id); empty means the session enclosing this process, which
+// requires running inside tmux (display-message then resolves the pane
+// from $TMUX/$TMUX_PANE).
+//
+// The returned Socket is the server's own answer, not the string we
+// reached it by. A share is keyed on that path, and one server has many
+// spellings -- `$TMUX`'s prefix, an empty default, a symlink, /tmp
+// against /private/tmp -- each of which would otherwise key a separate
+// share and let a second worker publish a session that is already
+// published.
+func Discover(r Runner, targetFlag string) (Target, error) {
+	args := []string{"display-message", "-p"}
+	if targetFlag != "" {
+		args = append(args, "-t", targetFlag)
+	} else {
+		enclosing := SocketFromEnv()
+		if enclosing == "" {
+			return Target{}, errors.New("not inside tmux -- pass --target SESSION (and --socket PATH for a non-default server)")
+		}
+		// display-message resolves against the server we are talking
+		// to, which is not the one the caller is sitting in when
+		// --socket points elsewhere. Publishing a session the user
+		// cannot see, read-write, is not a thing to guess at.
+		if sock := r.Socket(); sock != "" && !sameSocket(sock, enclosing) {
+			return Target{}, fmt.Errorf("--socket %s is a different tmux server than the one you are in (%s) -- pass --target SESSION to say which session to share", sock, enclosing)
+		}
+	}
+	args = append(args, "#{session_id}\t#{session_name}\t#{socket_path}")
+	out, err := r.Run(args...)
+	if err != nil {
+		return Target{}, err
+	}
+	fields := strings.Split(out, "\t")
+	if len(fields) < 2 || !strings.HasPrefix(fields[0], "$") {
+		return Target{}, fmt.Errorf("could not resolve tmux session (got %q)", out)
+	}
+	t := Target{SessionID: fields[0], SessionName: fields[1]}
+	if len(fields) > 2 {
+		t.Socket = strings.TrimSpace(fields[2])
+	}
+	return t, nil
+}
+
+// sameSocket reports whether two socket paths name the same tmux
+// server. Compared after resolving symlinks, since a path that points
+// at the enclosing server is the enclosing server however it is
+// spelled; an unresolvable path falls back to a literal match.
+func sameSocket(a, b string) bool {
+	if a == b {
+		return true
+	}
+	ra, err := filepath.EvalSymlinks(a)
+	if err != nil {
+		return false
+	}
+	rb, err := filepath.EvalSymlinks(b)
+	if err != nil {
+		return false
+	}
+	return ra == rb
+}
+
+var tmuxVersionRe = regexp.MustCompile(`(\d+)\.(\d+)`)
+
+// CheckVersion enforces the tmux >= 3.2 floor required by the read-only
+// attach behavior. Unparseable development versions are assumed current.
+func CheckVersion(r Runner) error {
+	out, err := r.Run("-V")
+	if err != nil {
+		return err
+	}
+	m := tmuxVersionRe.FindStringSubmatch(out)
+	if m == nil {
+		return nil
+	}
+	major, _ := strconv.Atoi(m[1])
+	minor, _ := strconv.Atoi(m[2])
+	if major > 3 || (major == 3 && minor >= 2) {
+		return nil
+	}
+	return fmt.Errorf("bitbang share needs tmux >= 3.2 (found %q) for read-only viewers", out)
+}
+
+// EffectiveWindowSize reports the window-size in force for the shared
+// session's current window, resolving inheritance (-A) so a
+// window-local override is visible rather than the server default that
+// it beats.
+//
+// It is only ever read. `window-size` is a WINDOW option, and neither
+// way of writing one fits a share: per-window misses any window opened
+// later, while -g reaches every unrelated session on the server, still
+// loses to a window-local override, and cannot be restored by one share
+// acting alone once two of them overlap. tmux already defaults to
+// "latest", the value a share wants, so the operator's configuration
+// stands and a share reports it instead.
+func EffectiveWindowSize(r Runner, sessionID string) string {
+	out, err := r.Run("show-options", "-w", "-t", sessionID, "-Aqv", "window-size")
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(out)
+}
+
+// AttachEnv returns the server-owned environment for the forced tmux
+// attach commands: base (the worker's own environment) minus TMUX and
+// TMUX_PANE -- the worker itself runs inside the management session,
+// and tmux refuses to attach when $TMUX is set -- with TERM defaulted
+// so the attach client can render.
+//
+// A capability-free TERM is treated as unset because tmux refuses to
+// attach under `dumb`.
+func AttachEnv(base []string) []string {
+	out := make([]string, 0, len(base)+1)
+	hasTerm := false
+	for _, kv := range base {
+		if strings.HasPrefix(kv, "TMUX=") || strings.HasPrefix(kv, "TMUX_PANE=") {
+			continue
+		}
+		if term, ok := strings.CutPrefix(kv, "TERM="); ok {
+			if usableTERM(term) {
+				hasTerm = true
+			} else {
+				continue
+			}
+		}
+		out = append(out, kv)
+	}
+	if !hasTerm {
+		out = append(out, "TERM=xterm-256color")
+	}
+	return out
+}
+
+// usableTERM reports whether a terminal type can carry a tmux client.
+func usableTERM(term string) bool {
+	switch term {
+	case "", "dumb", "unknown":
+		return false
+	}
+	return true
+}
+
+// ShellQuote single-quotes s for POSIX sh, for embedding in the shell
+// command string tmux new-session runs.
+func ShellQuote(s string) string {
+	if s == "" {
+		return "''"
+	}
+	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
+}

--- a/internal/share/tmux_integration_test.go
+++ b/internal/share/tmux_integration_test.go
@@ -1,0 +1,370 @@
+//go:build unix
+
+package share
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/richlegrand/bitbang/internal/streamtype"
+)
+
+// requireTmux skips local runs without a supported tmux. Linux CI installs
+// tmux so these tests run for pull requests.
+func requireTmux(t *testing.T) {
+	t.Helper()
+	if testing.Short() {
+		t.Skip("skipping tmux integration test in short mode")
+	}
+	if _, err := exec.LookPath("tmux"); err != nil {
+		t.Skip("tmux not installed")
+	}
+	if err := CheckVersion(NewRunner("")); err != nil {
+		t.Skipf("tmux too old: %v", err)
+	}
+}
+
+// isolatedServer starts a private tmux server on a throwaway socket
+// with one session, and kills the whole server at test end. Nothing
+// touches the developer's own tmux.
+func isolatedServer(t *testing.T) (*ExecRunner, string) {
+	t.Helper()
+	// Short base path on purpose: a Unix socket path is capped near
+	// 104 bytes, and t.TempDir()'s test-name-derived directory blows
+	// past that on macOS (/var/folders/...).
+	base, err := os.MkdirTemp("/tmp", "bbshare")
+	if err != nil {
+		t.Fatalf("temp dir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(base) })
+	socket := filepath.Join(base, "s")
+	r := NewRunner(socket)
+	if _, err := r.Run("new-session", "-d", "-s", "shared", "-x", "80", "-y", "24", "cat"); err != nil {
+		t.Skipf("cannot start isolated tmux server: %v", err)
+	}
+	t.Cleanup(func() { _, _ = r.Run("kill-server") })
+	return r, socket
+}
+
+// attachHandler builds the ShellHandler the share worker would build
+// for a peer in the given role.
+func attachHandler(socket, session string, viewOnly bool) *streamtype.ShellHandler {
+	h := streamtype.NewShell(nil, false)
+	argv := []string{"tmux", "-S", socket, "attach-session"}
+	if viewOnly {
+		argv = append(argv, "-r")
+	}
+	argv = append(argv, "-t", session)
+	h.ForcedArgv = argv
+	h.ForcedEnv = AttachEnv(os.Environ())
+	h.ViewOnly = viewOnly
+	return h
+}
+
+// TestAttachDeliversSessionOutput is the end-to-end claim of the
+// feature: a peer attaching over the forced argv sees the *running*
+// session's screen, not a fresh shell.
+func TestAttachDeliversSessionOutput(t *testing.T) {
+	requireTmux(t)
+	r, socket := isolatedServer(t)
+
+	// Put a recognizable marker on the shared session's screen before
+	// anyone attaches -- proving the attach shows existing state.
+	if _, err := r.Run("send-keys", "-t", "shared", "MARKER-ALREADY-RUNNING", "Enter"); err != nil {
+		t.Fatalf("send-keys: %v", err)
+	}
+
+	h := attachHandler(socket, "shared", false)
+	s := newTmuxCapture()
+	syn, _ := json.Marshal(map[string]interface{}{"type": "shell", "pty": true, "cols": 80, "rows": 24})
+	if err := h.OnSYN(s, syn, false); err != nil {
+		t.Fatalf("OnSYN: %v", err)
+	}
+	defer h.Close()
+
+	waitFor(t, "attached client to render the running session", func() bool {
+		return strings.Contains(s.text(), "MARKER-ALREADY-RUNNING")
+	})
+
+	// tmux itself must consider the client attached (and read-write).
+	out, err := r.Run("list-clients", "-t", "shared", "-F", "#{client_readonly}")
+	if err != nil {
+		t.Fatalf("list-clients: %v", err)
+	}
+	if out == "" {
+		t.Fatal("tmux reports no attached clients")
+	}
+	if strings.Contains(out, "1") {
+		t.Errorf("control peer attached read-only (client_readonly=%q)", out)
+	}
+}
+
+// TestViewerAttachesReadOnly checks the tmux-side half of the viewer
+// boundary: even if the transport gate were bypassed, the client tmux
+// hands the viewer is read-only and size-ignoring.
+func TestViewerAttachesReadOnly(t *testing.T) {
+	requireTmux(t)
+	r, socket := isolatedServer(t)
+
+	h := attachHandler(socket, "shared", true)
+	s := newTmuxCapture()
+	syn, _ := json.Marshal(map[string]interface{}{"type": "shell", "pty": true, "cols": 100, "rows": 40})
+	if err := h.OnSYN(s, syn, false); err != nil {
+		t.Fatalf("OnSYN: %v", err)
+	}
+	defer h.Close()
+
+	waitFor(t, "viewer client to register with tmux", func() bool {
+		out, _ := r.Run("list-clients", "-t", "shared", "-F", "#{client_readonly},#{client_flags}")
+		return strings.TrimSpace(out) != ""
+	})
+
+	out, err := r.Run("list-clients", "-t", "shared", "-F", "#{client_readonly},#{client_flags}")
+	if err != nil {
+		t.Fatalf("list-clients: %v", err)
+	}
+	line := strings.TrimSpace(strings.Split(out, "\n")[0])
+	readonly, flags, _ := strings.Cut(line, ",")
+	if readonly != "1" {
+		t.Errorf("viewer client_readonly = %q, want 1", readonly)
+	}
+	if !strings.Contains(flags, "ignore-size") {
+		t.Errorf("viewer client_flags = %q, want ignore-size among them", flags)
+	}
+}
+
+// An ignore-size viewer must not resize the window while a read-write client
+// is attached. A lone viewer still supplies tmux's only available size.
+func TestViewerCannotResizeWhileControlAttached(t *testing.T) {
+	requireTmux(t)
+	r, socket := isolatedServer(t)
+
+	if _, err := r.Run("set-option", "-g", "window-size", "latest"); err != nil {
+		t.Fatalf("set window-size: %v", err)
+	}
+
+	control := attachHandler(socket, "shared", false)
+	controlStream := newTmuxCapture()
+	bigSYN, _ := json.Marshal(map[string]interface{}{"type": "shell", "pty": true, "cols": 80, "rows": 24})
+	if err := control.OnSYN(controlStream, bigSYN, false); err != nil {
+		t.Fatalf("control OnSYN: %v", err)
+	}
+	defer control.Close()
+
+	waitFor(t, "control client to attach", func() bool {
+		out, _ := r.Run("list-clients", "-t", "shared", "-F", "#{client_readonly}")
+		return strings.Contains(out, "0")
+	})
+	time.Sleep(300 * time.Millisecond)
+	before, err := r.Run("display-message", "-p", "-t", "shared", "#{window_width}x#{window_height}")
+	if err != nil {
+		t.Fatalf("display-message: %v", err)
+	}
+
+	viewer := attachHandler(socket, "shared", true)
+	viewerStream := newTmuxCapture()
+	// Deliberately a phone-shaped geometry, far from the controller's.
+	smallSYN, _ := json.Marshal(map[string]interface{}{"type": "shell", "pty": true, "cols": 40, "rows": 12})
+	if err := viewer.OnSYN(viewerStream, smallSYN, false); err != nil {
+		t.Fatalf("viewer OnSYN: %v", err)
+	}
+	defer viewer.Close()
+
+	waitFor(t, "viewer client to attach", func() bool {
+		out, _ := r.Run("list-clients", "-t", "shared", "-F", "#{client_readonly}")
+		return strings.Contains(out, "1")
+	})
+	time.Sleep(500 * time.Millisecond) // let any (unwanted) resize settle
+
+	after, err := r.Run("display-message", "-p", "-t", "shared", "#{window_width}x#{window_height}")
+	if err != nil {
+		t.Fatalf("display-message: %v", err)
+	}
+	if after != before {
+		t.Errorf("viewer resized the shared window out from under the controller: %s -> %s", before, after)
+	}
+}
+
+// TestEffectiveWindowSizeResolvesInheritance pins down what the share
+// reports about sizing. window-size is a WINDOW option, so the value
+// that matters is the one in force for the shared window after
+// inheritance -- not the server-wide default, which any window-local
+// setting silently beats.
+func TestEffectiveWindowSizeResolvesInheritance(t *testing.T) {
+	requireTmux(t)
+	r, _ := isolatedServer(t)
+
+	// tmux's own default is what makes a share behave: the window
+	// follows whoever is currently driving it.
+	if got := EffectiveWindowSize(r, "shared"); got != "latest" {
+		t.Errorf("default effective window-size = %q, want latest", got)
+	}
+
+	// A window-local override must be what we report, because it is
+	// what tmux will actually obey.
+	if _, err := r.Run("set-option", "-w", "-t", "shared", "window-size", "manual"); err != nil {
+		t.Fatalf("set window-local override: %v", err)
+	}
+	if _, err := r.Run("set-option", "-g", "window-size", "latest"); err != nil {
+		t.Fatalf("set global: %v", err)
+	}
+	if got := EffectiveWindowSize(r, "shared"); got != "manual" {
+		t.Errorf("effective window-size = %q, want manual -- the window-local value wins over the global default", got)
+	}
+}
+
+// Sharing must not change global or unrelated-session window sizing.
+func TestShareLeavesWindowSizeAlone(t *testing.T) {
+	requireTmux(t)
+	r, socket := isolatedServer(t)
+
+	if _, err := r.Run("new-session", "-d", "-s", "bystander", "-x", "80", "-y", "24", "cat"); err != nil {
+		t.Fatalf("new-session: %v", err)
+	}
+	// An operator who deliberately configured something other than the
+	// default must find it unchanged afterwards.
+	if _, err := r.Run("set-option", "-g", "window-size", "smallest"); err != nil {
+		t.Fatalf("seed global: %v", err)
+	}
+
+	h := attachHandler(socket, "shared", false)
+	s := newTmuxCapture()
+	syn, _ := json.Marshal(map[string]interface{}{"type": "shell", "pty": true, "cols": 80, "rows": 24})
+	if err := h.OnSYN(s, syn, false); err != nil {
+		t.Fatalf("OnSYN: %v", err)
+	}
+	waitFor(t, "client to attach", func() bool {
+		out, _ := r.Run("list-clients", "-t", "shared", "-F", "#{client_readonly}")
+		return strings.TrimSpace(out) != ""
+	})
+	_ = EffectiveWindowSize(r, "shared") // the probe the share actually performs
+	h.Close()
+	waitFor(t, "attach client to exit", func() bool {
+		out, _ := r.Run("list-clients", "-t", "shared", "-F", "#{client_readonly}")
+		return strings.TrimSpace(out) == ""
+	})
+
+	if got, _ := r.Run("show-options", "-gqv", "window-size"); got != "smallest" {
+		t.Errorf("global window-size = %q after sharing, want the operator's smallest untouched", got)
+	}
+	if got := EffectiveWindowSize(r, "bystander"); got != "smallest" {
+		t.Errorf("unrelated session's window-size = %q, want smallest -- a share must not reach other sessions", got)
+	}
+}
+
+func TestSourceSessionLossDetected(t *testing.T) {
+	requireTmux(t)
+	r, socket := isolatedServer(t)
+
+	// Stand-in for the worker's management session. In production it is
+	// always there -- the worker runs inside it -- which is what keeps the
+	// server alive to answer after the shared session goes away. Without
+	// one, killing the only session takes the server with it and there
+	// is nobody left to ask.
+	if _, err := r.Run("new-session", "-d", "-s", "mgmt", "cat"); err != nil {
+		t.Fatalf("new-session: %v", err)
+	}
+	id, err := r.Run("display-message", "-p", "-t", "=shared:", "#{session_id}")
+	if err != nil {
+		t.Fatalf("display-message: %v", err)
+	}
+
+	if !strings.HasPrefix(id, "$") {
+		t.Fatalf("session id = %q; a watchdog given an empty id matches nothing and fires immediately, "+
+			"so the rest of this test would pass without proving anything", id)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	gone := watchSource(ctx, r, id, 20*time.Millisecond)
+
+	// It must be quiet while the session is there, or "it fired after
+	// the kill" says nothing about the kill.
+	select {
+	case <-gone:
+		t.Fatal("watchdog reported a session that was running")
+	case <-time.After(200 * time.Millisecond):
+	}
+
+	if _, err := r.Run("kill-session", "-t", "=shared"); err != nil {
+		t.Fatalf("kill-session: %v", err)
+	}
+	select {
+	case <-gone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("worker watchdog did not report the killed source session")
+	}
+	_ = socket
+}
+
+// TestUnreachableServerDoesNotEndTheShare is the other half, and the
+// one that used to be wrong: a socket that cannot be reached answers
+// every command with a non-zero exit, exactly as a killed session does.
+// Counting those toward a verdict ended a healthy share after fifteen
+// seconds of a permission problem that then fixed itself.
+func TestUnreachableServerDoesNotEndTheShare(t *testing.T) {
+	requireTmux(t)
+	if os.Getuid() == 0 {
+		t.Skip("root reaches sockets whatever their mode")
+	}
+	r, socket := isolatedServer(t)
+	if _, err := r.Run("new-session", "-d", "-s", "mgmt", "cat"); err != nil {
+		t.Fatalf("new-session: %v", err)
+	}
+	id, err := r.Run("display-message", "-p", "-t", "=shared:", "#{session_id}")
+	if err != nil {
+		t.Fatalf("display-message: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	gone := watchSource(ctx, r, id, 20*time.Millisecond)
+
+	if err := os.Chmod(socket, 0o000); err != nil {
+		t.Fatalf("chmod socket: %v", err)
+	}
+	select {
+	case <-gone:
+		_ = os.Chmod(socket, 0o600)
+		t.Fatal("an unreachable socket ended a share whose session was running the whole time")
+	case <-time.After(500 * time.Millisecond):
+	}
+
+	// And it still notices once it can see again.
+	if err := os.Chmod(socket, 0o600); err != nil {
+		t.Fatalf("restore socket: %v", err)
+	}
+	if _, err := r.Run("kill-session", "-t", "=shared"); err != nil {
+		t.Fatalf("kill-session: %v", err)
+	}
+	select {
+	case <-gone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("watchdog stayed blind after the socket came back")
+	}
+}
+
+// TestDiscoverAgainstRealTmux exercises the discovery format string
+// against a real tmux rather than a canned reply.
+func TestDiscoverAgainstRealTmux(t *testing.T) {
+	requireTmux(t)
+	r, _ := isolatedServer(t)
+
+	t.Setenv("TMUX", "") // force the explicit-target path
+	tgt, err := Discover(r, "shared")
+	if err != nil {
+		t.Fatalf("Discover: %v", err)
+	}
+	if !strings.HasPrefix(tgt.SessionID, "$") {
+		t.Errorf("SessionID = %q, want a $-prefixed tmux id", tgt.SessionID)
+	}
+	if tgt.SessionName != "shared" {
+		t.Errorf("SessionName = %q, want shared", tgt.SessionName)
+	}
+}

--- a/internal/share/tmux_integration_test.go
+++ b/internal/share/tmux_integration_test.go
@@ -141,53 +141,60 @@ func TestViewerAttachesReadOnly(t *testing.T) {
 
 // An ignore-size viewer must not resize the window while a read-write client
 // is attached. A lone viewer still supplies tmux's only available size.
+// Pinned under both window-size modes: latest (tmux's default) and smallest
+// (a common config, and the mode that would shrink everyone if a viewer's
+// size counted). ignore-size must hold regardless of mode.
 func TestViewerCannotResizeWhileControlAttached(t *testing.T) {
 	requireTmux(t)
-	r, socket := isolatedServer(t)
+	for _, windowSize := range []string{"latest", "smallest"} {
+		t.Run(windowSize, func(t *testing.T) {
+			r, socket := isolatedServer(t)
 
-	if _, err := r.Run("set-option", "-g", "window-size", "latest"); err != nil {
-		t.Fatalf("set window-size: %v", err)
-	}
+			if _, err := r.Run("set-option", "-g", "window-size", windowSize); err != nil {
+				t.Fatalf("set window-size: %v", err)
+			}
 
-	control := attachHandler(socket, "shared", false)
-	controlStream := newTmuxCapture()
-	bigSYN, _ := json.Marshal(map[string]interface{}{"type": "shell", "pty": true, "cols": 80, "rows": 24})
-	if err := control.OnSYN(controlStream, bigSYN, false); err != nil {
-		t.Fatalf("control OnSYN: %v", err)
-	}
-	defer control.Close()
+			control := attachHandler(socket, "shared", false)
+			controlStream := newTmuxCapture()
+			bigSYN, _ := json.Marshal(map[string]interface{}{"type": "shell", "pty": true, "cols": 80, "rows": 24})
+			if err := control.OnSYN(controlStream, bigSYN, false); err != nil {
+				t.Fatalf("control OnSYN: %v", err)
+			}
+			defer control.Close()
 
-	waitFor(t, "control client to attach", func() bool {
-		out, _ := r.Run("list-clients", "-t", "shared", "-F", "#{client_readonly}")
-		return strings.Contains(out, "0")
-	})
-	time.Sleep(300 * time.Millisecond)
-	before, err := r.Run("display-message", "-p", "-t", "shared", "#{window_width}x#{window_height}")
-	if err != nil {
-		t.Fatalf("display-message: %v", err)
-	}
+			waitFor(t, "control client to attach", func() bool {
+				out, _ := r.Run("list-clients", "-t", "shared", "-F", "#{client_readonly}")
+				return strings.Contains(out, "0")
+			})
+			time.Sleep(300 * time.Millisecond)
+			before, err := r.Run("display-message", "-p", "-t", "shared", "#{window_width}x#{window_height}")
+			if err != nil {
+				t.Fatalf("display-message: %v", err)
+			}
 
-	viewer := attachHandler(socket, "shared", true)
-	viewerStream := newTmuxCapture()
-	// Deliberately a phone-shaped geometry, far from the controller's.
-	smallSYN, _ := json.Marshal(map[string]interface{}{"type": "shell", "pty": true, "cols": 40, "rows": 12})
-	if err := viewer.OnSYN(viewerStream, smallSYN, false); err != nil {
-		t.Fatalf("viewer OnSYN: %v", err)
-	}
-	defer viewer.Close()
+			viewer := attachHandler(socket, "shared", true)
+			viewerStream := newTmuxCapture()
+			// Deliberately a phone-shaped geometry, far from the controller's.
+			smallSYN, _ := json.Marshal(map[string]interface{}{"type": "shell", "pty": true, "cols": 40, "rows": 12})
+			if err := viewer.OnSYN(viewerStream, smallSYN, false); err != nil {
+				t.Fatalf("viewer OnSYN: %v", err)
+			}
+			defer viewer.Close()
 
-	waitFor(t, "viewer client to attach", func() bool {
-		out, _ := r.Run("list-clients", "-t", "shared", "-F", "#{client_readonly}")
-		return strings.Contains(out, "1")
-	})
-	time.Sleep(500 * time.Millisecond) // let any (unwanted) resize settle
+			waitFor(t, "viewer client to attach", func() bool {
+				out, _ := r.Run("list-clients", "-t", "shared", "-F", "#{client_readonly}")
+				return strings.Contains(out, "1")
+			})
+			time.Sleep(500 * time.Millisecond) // let any (unwanted) resize settle
 
-	after, err := r.Run("display-message", "-p", "-t", "shared", "#{window_width}x#{window_height}")
-	if err != nil {
-		t.Fatalf("display-message: %v", err)
-	}
-	if after != before {
-		t.Errorf("viewer resized the shared window out from under the controller: %s -> %s", before, after)
+			after, err := r.Run("display-message", "-p", "-t", "shared", "#{window_width}x#{window_height}")
+			if err != nil {
+				t.Fatalf("display-message: %v", err)
+			}
+			if after != before {
+				t.Errorf("viewer resized the shared window out from under the controller: %s -> %s", before, after)
+			}
+		})
 	}
 }
 

--- a/internal/share/worker.go
+++ b/internal/share/worker.go
@@ -1,0 +1,569 @@
+package share
+
+import (
+	"context"
+	"crypto/subtle"
+	"errors"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/richlegrand/bitbang/internal/auth"
+	"github.com/richlegrand/bitbang/internal/identity"
+	"github.com/richlegrand/bitbang/internal/peer"
+	"github.com/richlegrand/bitbang/internal/protocol"
+	"github.com/richlegrand/bitbang/internal/session"
+	"github.com/richlegrand/bitbang/internal/shellweb"
+	"github.com/richlegrand/bitbang/internal/signaling"
+	"github.com/richlegrand/bitbang/internal/streamtype"
+)
+
+const (
+	// MaxViewers is the largest accepted --max-viewers value.
+	MaxViewers = 1024
+	// MaxTTL is the longest finite share lifetime.
+	MaxTTL = 365 * 24 * time.Hour
+
+	peerEstablishTimeout = 60 * time.Second
+	refusedPeerGrace     = 20 * time.Second
+	sourceCheckInterval  = 5 * time.Second
+	maxPendingPeerBytes  = 256 << 10
+)
+
+// ErrPreempted means another process registered the worker's ephemeral UID.
+var ErrPreempted = signaling.ErrPreempted
+
+// WorkerConfig describes one tmux session publication.
+type WorkerConfig struct {
+	SessionID   string
+	SessionName string
+	MgmtSession string
+	StateDir    string
+	Server      string
+	Socket      string
+	TTL         time.Duration
+	MaxViewers  int
+	ReadOnly    bool
+	Verbose     bool
+
+	// Nonce names the start attempt this worker belongs to. It is
+	// written into the state file and means nothing to the worker
+	// itself; the parent uses it to tell this worker's state from a
+	// predecessor's leftovers. See State.Nonce.
+	Nonce string
+
+	Runner Runner
+	Env    []string
+}
+
+// Worker owns signaling, peer admission, and teardown for one share.
+type Worker struct {
+	cfg       WorkerConfig
+	runner    Runner
+	id        *identity.Identity
+	signaling *signaling.Client
+
+	controlCode string
+	viewCode    string
+	controlURL  string
+	viewURL     string
+
+	controlArgv []string
+	viewArgv    []string
+	forcedEnv   []string
+	controlWeb  http.Handler
+	viewWeb     http.Handler
+	control     *roleSlots
+	viewers     *roleSlots
+
+	mu        sync.Mutex
+	peers     map[string]*sharePeer
+	closed    bool
+	startedAt time.Time
+	expiresAt time.Time
+	readyOnce sync.Once
+	errOnce   sync.Once
+	errs      chan error
+}
+
+// NewWorker validates cfg and creates the ephemeral role credentials.
+func NewWorker(cfg WorkerConfig) (*Worker, error) {
+	if cfg.SessionID == "" || cfg.MgmtSession == "" || cfg.StateDir == "" {
+		return nil, errors.New("share worker: session, management session, and state directory are required")
+	}
+	if cfg.Server == "" {
+		cfg.Server = "bitba.ng"
+	}
+	if cfg.MaxViewers < 0 || cfg.MaxViewers > MaxViewers {
+		return nil, fmt.Errorf("share worker: max viewers must be between 0 and %d", MaxViewers)
+	}
+	if cfg.TTL < 0 || cfg.TTL > MaxTTL || cfg.TTL%time.Second != 0 {
+		return nil, fmt.Errorf("share worker: TTL must be 0 or a whole number of seconds up to %s", MaxTTL)
+	}
+	if cfg.Runner == nil {
+		cfg.Runner = NewRunner(cfg.Socket)
+	}
+	if cfg.Env == nil {
+		cfg.Env = os.Environ()
+	}
+
+	id, err := identity.Load("share", true)
+	if err != nil {
+		return nil, fmt.Errorf("create ephemeral identity: %w", err)
+	}
+	controlCode := ""
+	viewCode := id.Code
+	if !cfg.ReadOnly {
+		controlCode = id.Code
+		viewCode, err = distinctAccessCode(controlCode, NewAccessCode)
+		if err != nil {
+			return nil, fmt.Errorf("create view credential: %w", err)
+		}
+	}
+
+	tmuxBase := []string{"tmux"}
+	if cfg.Socket != "" {
+		tmuxBase = append(tmuxBase, "-S", cfg.Socket)
+	}
+	controlArgv := append(append([]string(nil), tmuxBase...), "attach-session", "-t", cfg.SessionID)
+	viewArgv := append(append([]string(nil), tmuxBase...), "attach-session", "-r", "-t", cfg.SessionID)
+
+	sc := signaling.NewClient(cfg.Server, id)
+	sc.Verbose = cfg.Verbose
+	sc.WantCode = false
+	sc.OnPreempted = func() {}
+
+	w := &Worker{
+		cfg:         cfg,
+		runner:      cfg.Runner,
+		id:          id,
+		signaling:   sc,
+		controlCode: controlCode,
+		viewCode:    viewCode,
+		controlArgv: controlArgv,
+		viewArgv:    viewArgv,
+		forcedEnv:   AttachEnv(cfg.Env),
+		controlWeb:  shellweb.New().HTTPHandler(),
+		viewWeb:     shellweb.New(shellweb.WithViewOnly()).HTTPHandler(),
+		control:     newRoleSlots(1, "share already has a controller -- try again after they disconnect"),
+		viewers:     newRoleSlots(cfg.MaxViewers, fmt.Sprintf("share is full (max %d viewers)", cfg.MaxViewers)),
+		peers:       make(map[string]*sharePeer),
+		errs:        make(chan error, 1),
+	}
+	if cfg.ReadOnly {
+		w.control = newRoleSlots(0, "this share is view-only")
+	}
+	w.controlURL = ""
+	if !cfg.ReadOnly {
+		w.controlURL = sc.CodeURL(controlCode, "ephemeral")
+	}
+	w.viewURL = sc.CodeURL(viewCode, "ephemeral")
+	return w, nil
+}
+
+func distinctAccessCode(exclude string, generate func() (string, error)) (string, error) {
+	for range 8 {
+		code, err := generate()
+		if err != nil {
+			return "", err
+		}
+		if code != exclude {
+			return code, nil
+		}
+	}
+	return "", errors.New("could not generate a distinct access code")
+}
+
+// Run publishes the target until the context is canceled, the TTL expires,
+// the source session disappears, or signaling is preempted.
+func (w *Worker) Run(ctx context.Context) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	w.mu.Lock()
+	if !w.startedAt.IsZero() {
+		w.mu.Unlock()
+		return errors.New("share worker can only run once")
+	}
+	w.startedAt = time.Now()
+	if w.cfg.TTL > 0 {
+		w.expiresAt = w.startedAt.Add(w.cfg.TTL)
+	}
+	w.mu.Unlock()
+	defer w.shutdown()
+	runCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	if _, err := w.runner.Run("has-session", "-t", w.cfg.SessionID); err != nil {
+		return fmt.Errorf("source session is not running: %w", err)
+	}
+	w.signaling.OnReady = w.onReady
+
+	connectDone := make(chan error, 1)
+	go func() { connectDone <- w.signaling.Connect(w.handleMessage) }()
+
+	sourceGone := watchSource(runCtx, w.runner, w.cfg.SessionID, sourceCheckInterval)
+	var ttl *time.Timer
+	var ttlC <-chan time.Time
+	if w.cfg.TTL > 0 {
+		ttl = time.NewTimer(w.cfg.TTL)
+		ttlC = ttl.C
+		defer ttl.Stop()
+	}
+
+	select {
+	case <-ctx.Done():
+		log.Printf("Share ending: requested")
+		return nil
+	case <-ttlC:
+		log.Printf("Share ending: TTL expired")
+		return nil
+	case <-sourceGone:
+		log.Printf("Share ending: source session gone")
+		return nil
+	case err := <-w.errs:
+		return err
+	case err := <-connectDone:
+		if errors.Is(err, signaling.ErrPreempted) {
+			return ErrPreempted
+		}
+		if err != nil {
+			return fmt.Errorf("signaling stopped: %w", err)
+		}
+		return nil
+	}
+}
+
+// authorize classifies a presented access code into a role.
+//
+// Both comparisons run on every call, so the timing of a rejection does
+// not say which of the two codes a guess was tested against. That holds
+// for contents only: subtle.ConstantTimeCompare returns as soon as the
+// lengths differ, so a candidate of the wrong length stays
+// distinguishable as one.
+//
+// A read-only share issues a single credential -- the identity's own
+// code, serving as the view code -- and grants control to nothing.
+func (w *Worker) authorize(code string) (protocol.Access, bool) {
+	// With no control code to test against, the probe is pointed at the
+	// view code so both comparisons still run.
+	controlProbe := w.controlCode
+	if w.cfg.ReadOnly {
+		controlProbe = w.viewCode
+	}
+	isControl := subtle.ConstantTimeCompare([]byte(code), []byte(controlProbe)) == 1
+	isView := subtle.ConstantTimeCompare([]byte(code), []byte(w.viewCode)) == 1
+	if isControl && !w.cfg.ReadOnly {
+		return protocol.AccessControl, true
+	}
+	if isView {
+		return protocol.AccessView, true
+	}
+	return protocol.AccessDefault, false
+}
+
+// onReady writes the state file after the first successful signaling
+// registration. The parent command blocks on that file appearing, so
+// writing it here is what guarantees the URLs it prints are already
+// answerable.
+func (w *Worker) onReady() {
+	w.readyOnce.Do(func() {
+		w.mu.Lock()
+		if w.closed {
+			w.mu.Unlock()
+			return
+		}
+		state := &State{
+			Socket:      w.cfg.Socket,
+			SessionID:   w.cfg.SessionID,
+			SessionName: w.cfg.SessionName,
+			MgmtSession: w.cfg.MgmtSession,
+			UID:         w.id.UID,
+			Server:      w.cfg.Server,
+			Nonce:       w.cfg.Nonce,
+			ControlURL:  w.controlURL,
+			ViewURL:     w.viewURL,
+			MaxViewers:  w.cfg.MaxViewers,
+			CreatedAt:   w.startedAt,
+			ExpiresAt:   w.expiresAt,
+			TTLSeconds:  int(w.cfg.TTL / time.Second),
+		}
+		err := SaveState(w.cfg.StateDir, state)
+		w.mu.Unlock()
+		if err != nil {
+			w.report(fmt.Errorf("write share state: %w", err))
+			return
+		}
+		log.Printf("Share registered: session %s (%s), TTL %s", w.cfg.SessionID, w.cfg.SessionName, w.cfg.TTL)
+	})
+}
+
+func (w *Worker) report(err error) {
+	w.errOnce.Do(func() { w.errs <- err })
+}
+
+func (w *Worker) handleMessage(msg signaling.Message) {
+	switch msgType, _ := msg["type"].(string); msgType {
+	case "request":
+		w.handleRequest(msg)
+	case "answer":
+		w.handleAnswer(msg)
+	case "candidate":
+		w.handleCandidate(msg)
+	case "error":
+		log.Printf("Signaling error: %v", msg["message"])
+	}
+}
+
+// handleRequest builds a peer connection for an incoming request and
+// starts its establishment deadline. A request over the connection cap,
+// or one reusing a client ID that is already active, is dropped in
+// silence: there is no data channel yet to explain a refusal over.
+//
+// The cap is re-checked once the connection exists, because building it
+// runs without the lock and a shutdown can finish in that gap.
+// Signaling dispatches serially today, so a second request cannot
+// arrive meanwhile; the check does not rely on that staying true.
+func (w *Worker) handleRequest(msg signaling.Message) {
+	clientID, _ := msg["client_id"].(string)
+	if clientID == "" {
+		return
+	}
+
+	w.mu.Lock()
+	maxPeers := w.cfg.MaxViewers + 5
+	full := w.closed || len(w.peers) >= maxPeers
+	_, duplicate := w.peers[clientID]
+	w.mu.Unlock()
+	if full || duplicate {
+		log.Printf("Rejecting %s: share is at its connection limit or client ID is already active", clientID)
+		return
+	}
+
+	p := &sharePeer{}
+	conn, err := peer.HandleRequest(msg, w.signaling, w.id, p.handleMessage, w.cfg.Verbose)
+	if err != nil {
+		log.Printf("Failed to create peer connection: %v", err)
+		return
+	}
+	p.setConn(conn)
+	conn.Authorize = w.authorize
+
+	w.mu.Lock()
+	if w.closed || len(w.peers) >= maxPeers || w.peers[clientID] != nil {
+		w.mu.Unlock()
+		conn.Close()
+		return
+	}
+	w.peers[clientID] = p
+	w.mu.Unlock()
+
+	conn.SetOnClose(func() { w.dropPeer(clientID, p, "connection closed") })
+	p.armEstablishment(peerEstablishTimeout, func() {
+		w.dropPeer(clientID, p, "did not finish connecting within "+peerEstablishTimeout.String())
+	})
+}
+
+// handleAnswer verifies the connector's answer and admits the peer. A
+// rejected answer closes the connection: a wrong code or a mismatched
+// fingerprint gets no second attempt on the same handshake, and pion
+// refuses a repeat answer anyway.
+func (w *Worker) handleAnswer(msg signaling.Message) {
+	clientID, _ := msg["client_id"].(string)
+	p := w.peer(clientID)
+	if p == nil {
+		return
+	}
+	sdp, _ := msg["sdp"].(string)
+	encrypted, _ := msg["encrypted_request"].(string)
+	if err := p.conn.HandleAnswer(sdp, encrypted); err != nil {
+		log.Printf("Failed to handle answer: %v", err)
+		p.conn.Close()
+		return
+	}
+	w.buildSession(clientID, p)
+}
+
+func (w *Worker) handleCandidate(msg signaling.Message) {
+	clientID, _ := msg["client_id"].(string)
+	p := w.peer(clientID)
+	if p == nil {
+		return
+	}
+	candidate, _ := msg["candidate"].(map[string]interface{})
+	if err := p.conn.AddICECandidate(candidate); err != nil && w.cfg.Verbose {
+		log.Printf("Candidate for %s: %v", clientID, err)
+	}
+}
+
+func (w *Worker) peer(clientID string) *sharePeer {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.closed {
+		return nil
+	}
+	return w.peers[clientID]
+}
+
+// buildSession admits an authorized peer: it pins the peer to the tmux
+// command its role allows, takes the matching role slot, and installs
+// the session. Frames that arrive before that point are queued by
+// handleMessage and delivered once the session exists, so nothing is
+// lost and nothing runs before a role has been assigned.
+//
+// A peer whose role is full still gets a session, backed by a handler
+// that refuses every terminal and says why. Dropping the connection
+// outright would reach the browser as a failed connection, pointing the
+// user at the wrong cause.
+func (w *Worker) buildSession(clientID string, p *sharePeer) {
+	access := p.conn.Access()
+	sh := streamtype.NewShell(nil, w.cfg.Verbose)
+	sh.ForcedEnv = w.forcedEnv
+
+	var front http.Handler
+	var slots *roleSlots
+	switch access {
+	case protocol.AccessControl:
+		sh.ForcedArgv = w.controlArgv
+		front = w.controlWeb
+		slots = w.control
+	case protocol.AccessView:
+		sh.ForcedArgv = w.viewArgv
+		sh.ViewOnly = true
+		front = w.viewWeb
+		slots = w.viewers
+	default:
+		w.dropPeer(clientID, p, "answer did not grant a role")
+		return
+	}
+
+	release, busy := slots.acquire()
+	refused := release == nil
+	if refused {
+		log.Printf("Peer %s refused: %s", clientID, busy)
+		sh.AcquireSlot = func() (func(), string) { return nil, busy }
+	} else if !p.hold(release) {
+		release()
+		sh.Close()
+		return
+	} else {
+		var streamTaken bool
+		var streamMu sync.Mutex
+		sh.AcquireSlot = func() (func(), string) {
+			streamMu.Lock()
+			defer streamMu.Unlock()
+			if p.isClosed() {
+				return nil, "this connection is closing"
+			}
+			if streamTaken {
+				return nil, "this connection already has a terminal open"
+			}
+			streamTaken = true
+			return func() {
+				streamMu.Lock()
+				streamTaken = false
+				streamMu.Unlock()
+			}, ""
+		}
+	}
+
+	sess := session.New(p.conn.DC, auth.New(""), w.cfg.Verbose,
+		sh, streamtype.NewHTTPLocal(front, w.cfg.Verbose))
+	sess.Access = access
+	sess.OnReady = p.markEstablished
+	if !p.publish(sh, sess) {
+		sh.Close()
+		return
+	}
+	if refused {
+		p.armRefusal(refusedPeerGrace, func() {
+			w.dropPeer(clientID, p, "refused peer's grace elapsed")
+		})
+	}
+	log.Printf("Peer %s authorized: %s", clientID, access)
+}
+
+// dropPeer tears a peer down and forgets it. Every trigger calls this;
+// only the call that does the work logs.
+func (w *Worker) dropPeer(clientID string, p *sharePeer, why string) {
+	if !p.teardown() {
+		return
+	}
+	w.mu.Lock()
+	if w.peers[clientID] == p {
+		delete(w.peers, clientID)
+	}
+	w.mu.Unlock()
+	log.Printf("Peer %s gone: %s", clientID, why)
+}
+
+// shutdown stops signaling and tears every peer down in parallel. It leaves
+// state removal to a later CLI command, which can hold the target lifecycle
+// lock across the read, ownership decision, and removal.
+func (w *Worker) shutdown() {
+	w.mu.Lock()
+	if w.closed {
+		w.mu.Unlock()
+		return
+	}
+	w.closed = true
+	peers := make([]*sharePeer, 0, len(w.peers))
+	for _, p := range w.peers {
+		peers = append(peers, p)
+	}
+	w.peers = make(map[string]*sharePeer)
+	w.mu.Unlock()
+
+	w.signaling.Stop()
+	var wg sync.WaitGroup
+	for _, p := range peers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			p.teardown()
+		}()
+	}
+	wg.Wait()
+}
+
+// watchSource closes the returned channel after a successful list-sessions
+// response no longer contains the source. A failed tmux command is ignored
+// because it cannot distinguish a missing session from an unreachable server.
+func watchSource(ctx context.Context, runner Runner, sessionID string, interval time.Duration) <-chan struct{} {
+	gone := make(chan struct{})
+	go func() {
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				out, err := runner.Run("list-sessions", "-F", "#{session_id}")
+				if err != nil {
+					continue
+				}
+				if !listsSession(out, sessionID) {
+					close(gone)
+					return
+				}
+			}
+		}
+	}()
+	return gone
+}
+
+// listsSession reports whether a `list-sessions -F '#{session_id}'`
+// listing contains an exact session ID.
+func listsSession(listing, sessionID string) bool {
+	for _, line := range strings.Split(listing, "\n") {
+		if strings.TrimSpace(line) == sessionID {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/share/worker_peer.go
+++ b/internal/share/worker_peer.go
@@ -1,0 +1,279 @@
+package share
+
+import (
+	"sync"
+	"time"
+
+	"github.com/richlegrand/bitbang/internal/peer"
+	"github.com/richlegrand/bitbang/internal/session"
+	"github.com/richlegrand/bitbang/internal/streamtype"
+)
+
+// sharePeer owns one connection's role reservation, session, and tmux client.
+// teardown releases them exactly once regardless of which close path wins.
+type sharePeer struct {
+	conn *peer.Connection
+
+	mu      sync.Mutex
+	closed  bool
+	shell   *streamtype.ShellHandler
+	session *session.Session
+	// deliver hands one frame to the session. A field rather than a
+	// direct call so a test can substitute a delivery that blocks or
+	// counts, the same seam Session.sendFrame uses.
+	deliver func([]byte)
+	// dispatching marks the drain goroutine as running, so frames
+	// arriving mid-drain queue behind the backlog and stay in order.
+	dispatching   bool
+	pending       [][]byte
+	pendingBytes  int
+	releases      []func()
+	establishment *time.Timer
+	refusal       *time.Timer
+}
+
+// handleMessage routes an inbound data-channel frame to the session,
+// queueing it while there is none. Frames start arriving the moment the
+// channel opens, which can precede the session: the browser sends its
+// stream-0 connect immediately, and losing that frame would hang the
+// handshake it belongs to. A peer that fills the queue past
+// maxPendingPeerBytes before its session exists is disconnected.
+func (p *sharePeer) handleMessage(data []byte) {
+	p.mu.Lock()
+	if p.closed {
+		p.mu.Unlock()
+		return
+	}
+	if p.session == nil || p.dispatching {
+		if p.pendingBytes+len(data) > maxPendingPeerBytes {
+			conn := p.conn
+			p.mu.Unlock()
+			if conn != nil {
+				conn.Close()
+			}
+			return
+		}
+		p.pending = append(p.pending, append([]byte(nil), data...))
+		p.pendingBytes += len(data)
+		p.mu.Unlock()
+		return
+	}
+	deliver := p.deliver
+	p.mu.Unlock()
+	deliver(data)
+}
+
+// hold transfers a reservation to teardown. A false return leaves ownership
+// with the caller because teardown has already run.
+func (p *sharePeer) hold(release func()) bool {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.closed {
+		return false
+	}
+	p.releases = append(p.releases, release)
+	return true
+}
+
+// publish installs the session atomically with respect to teardown and drains
+// early frames on a per-peer goroutine. It returns false if teardown won.
+//
+// Delivery must not run on the signaling read loop: a congested PTY write can
+// block and would otherwise stop signaling for every peer.
+func (p *sharePeer) publish(sh *streamtype.ShellHandler, sess *session.Session) bool {
+	p.mu.Lock()
+	if p.closed {
+		p.mu.Unlock()
+		return false
+	}
+	p.shell = sh
+	p.session = sess
+	if p.deliver == nil {
+		p.deliver = sess.HandleMessage
+	}
+	p.dispatching = true
+	batch := p.takePendingLocked()
+	p.mu.Unlock()
+
+	go p.drain(batch)
+	return true
+}
+
+// drain delivers the backlog, then whatever arrived while it was
+// working, until the queue comes up empty or the peer goes away.
+// Clearing dispatching under the lock is what hands routing back to
+// handleMessage's direct path with no frame overtaking another.
+func (p *sharePeer) drain(batch [][]byte) {
+	defer func() {
+		p.mu.Lock()
+		p.dispatching = false
+		p.mu.Unlock()
+	}()
+
+	for {
+		for _, data := range batch {
+			// Stop between frames so teardown cannot be followed by delivery
+			// of the rest of the backlog.
+			p.mu.Lock()
+			deliver, closed := p.deliver, p.closed
+			p.mu.Unlock()
+			if closed {
+				return
+			}
+			deliver(data)
+		}
+
+		p.mu.Lock()
+		if p.closed {
+			p.mu.Unlock()
+			return
+		}
+		batch = p.takePendingLocked()
+		if len(batch) == 0 {
+			p.mu.Unlock()
+			return
+		}
+		p.mu.Unlock()
+	}
+}
+
+func (p *sharePeer) takePendingLocked() [][]byte {
+	batch := p.pending
+	p.pending = nil
+	p.pendingBytes = 0
+	return batch
+}
+
+// isClosed reports whether teardown has run. Stream admission checks it
+// so a frame already in flight when the peer died cannot open a terminal
+// on the way out.
+func (p *sharePeer) isClosed() bool {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.closed
+}
+
+// armEstablishment bounds the time from request to a completed stream-0
+// handshake. This also covers peers that authorize but never finish ICE.
+func (p *sharePeer) armEstablishment(after time.Duration, expire func()) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if !p.closed {
+		p.establishment = time.AfterFunc(after, expire)
+	}
+}
+
+// markEstablished cancels the establishment deadline. Wired to the
+// session's readiness callback, which fires once the stream-0 handshake
+// completes over an open data channel.
+func (p *sharePeer) markEstablished() {
+	p.mu.Lock()
+	if p.establishment != nil {
+		p.establishment.Stop()
+		p.establishment = nil
+	}
+	p.mu.Unlock()
+}
+
+// armRefusal starts the grace period for a peer turned away because its
+// role was full. It stays connected long enough to load the page and
+// read why, then goes, so a full share cannot be pinned open by peers
+// that will never be admitted.
+func (p *sharePeer) armRefusal(after time.Duration, expire func()) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if !p.closed {
+		p.refusal = time.AfterFunc(after, expire)
+	}
+}
+
+// teardown hands back every reservation, kills the peer's tmux client,
+// and closes the connection. It reports whether this call did the work,
+// so callers log and drop map entries exactly once.
+//
+// The handler is read under the same lock publish writes it under, which
+// keeps the two ordered: either teardown sees a live peer and closes its
+// handler, or publish finds the peer closed and declines.
+func (p *sharePeer) teardown() bool {
+	p.mu.Lock()
+	if p.closed {
+		p.mu.Unlock()
+		return false
+	}
+	p.closed = true
+	if p.establishment != nil {
+		p.establishment.Stop()
+	}
+	if p.refusal != nil {
+		p.refusal.Stop()
+	}
+	sh := p.shell
+	conn := p.conn
+	releases := p.releases
+	p.releases = nil
+	p.pending = nil
+	p.pendingBytes = 0
+	p.mu.Unlock()
+
+	if sh != nil {
+		sh.Close()
+	}
+	for _, release := range releases {
+		release()
+	}
+	if conn != nil {
+		conn.Close()
+	}
+	return true
+}
+
+// setConn attaches the peer connection. It is written after
+// peer.HandleRequest returns but read from pion's callbacks, so it
+// takes the same lock as every other late-bound field.
+func (p *sharePeer) setConn(conn *peer.Connection) {
+	p.mu.Lock()
+	p.conn = conn
+	p.mu.Unlock()
+}
+
+// roleSlots is the admission counter behind the single-controller rule
+// and --max-viewers. A slot is taken when a peer is authorized and held
+// for as long as it stays connected. Taking one only when a terminal
+// opens would leave both limits unenforced, since a peer can finish the
+// handshake and never open one.
+type roleSlots struct {
+	mu   sync.Mutex
+	used int
+	max  int
+	busy string
+}
+
+// newRoleSlots returns a pool of max slots. busy is what a refused peer
+// is told. A read-only share sizes its control pool at zero, though
+// that is a backstop: authorize never grants control on such a share,
+// so nothing reaches the pool to be refused.
+func newRoleSlots(max int, busy string) *roleSlots {
+	return &roleSlots{max: max, busy: busy}
+}
+
+// acquire takes a slot and returns the func that gives it back, or nil
+// and the busy message when the pool is full.
+//
+// The returned release function is idempotent so competing cleanup paths
+// cannot decrement the pool twice.
+func (r *roleSlots) acquire() (func(), string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.used >= r.max {
+		return nil, r.busy
+	}
+	r.used++
+	var once sync.Once
+	return func() {
+		once.Do(func() {
+			r.mu.Lock()
+			r.used--
+			r.mu.Unlock()
+		})
+	}, ""
+}

--- a/internal/share/worker_test.go
+++ b/internal/share/worker_test.go
@@ -1,0 +1,374 @@
+package share
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/richlegrand/bitbang/internal/protocol"
+	"github.com/richlegrand/bitbang/internal/session"
+	"github.com/richlegrand/bitbang/internal/streamtype"
+)
+
+func TestNewWorkerValidatesLimits(t *testing.T) {
+	base := WorkerConfig{
+		SessionID:   "$1",
+		MgmtSession: "mgmt",
+		StateDir:    t.TempDir(),
+		MaxViewers:  1,
+		Runner:      newFakeRunner(),
+	}
+	for _, mutate := range []func(*WorkerConfig){
+		func(c *WorkerConfig) { c.MaxViewers = -1 },
+		func(c *WorkerConfig) { c.MaxViewers = MaxViewers + 1 },
+		func(c *WorkerConfig) { c.TTL = 1500 * time.Millisecond },
+		func(c *WorkerConfig) { c.TTL = MaxTTL + time.Second },
+	} {
+		cfg := base
+		mutate(&cfg)
+		if _, err := NewWorker(cfg); err == nil {
+			t.Fatalf("NewWorker accepted invalid config: %+v", cfg)
+		}
+	}
+}
+
+func TestReadOnlyWorkerHasOnlyViewCredential(t *testing.T) {
+	w, err := NewWorker(WorkerConfig{
+		SessionID:   "$1",
+		MgmtSession: "mgmt",
+		StateDir:    t.TempDir(),
+		MaxViewers:  1,
+		ReadOnly:    true,
+		Runner:      newFakeRunner(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if w.controlCode != "" || w.controlURL != "" {
+		t.Fatalf("read-only worker created control access: code=%q URL=%q", w.controlCode, w.controlURL)
+	}
+	if w.viewCode != w.id.Code {
+		t.Error("read-only worker generated a second credential instead of using its identity code for viewing")
+	}
+	if access, ok := w.authorize(w.viewCode); !ok || access != protocol.AccessView {
+		t.Fatalf("view credential authorized as (%q, %v)", access, ok)
+	}
+}
+
+func TestDistinctAccessCodeRetriesCollision(t *testing.T) {
+	codes := []string{"same", "same", "different"}
+	code, err := distinctAccessCode("same", func() (string, error) {
+		next := codes[0]
+		codes = codes[1:]
+		return next, nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if code != "different" {
+		t.Fatalf("distinctAccessCode = %q, want different", code)
+	}
+}
+
+func TestWorkerPublishesStateOnceAndNotAfterShutdown(t *testing.T) {
+	stateDir := filepath.Join(t.TempDir(), "active")
+	w, err := NewWorker(WorkerConfig{
+		SessionID:   "$3",
+		SessionName: "work",
+		MgmtSession: "mgmt",
+		StateDir:    stateDir,
+		Server:      "example.test",
+		TTL:         time.Minute,
+		MaxViewers:  4,
+		Runner:      newFakeRunner(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	w.startedAt = time.Now()
+	w.expiresAt = w.startedAt.Add(time.Minute)
+	w.onReady()
+
+	state, err := LoadState(stateDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if state == nil || state.ControlURL == "" || state.ViewURL == "" || state.ControlURL == state.ViewURL {
+		t.Fatalf("worker published invalid role URLs: %+v", state)
+	}
+	if state.TTLSeconds != 60 || state.MaxViewers != 4 {
+		t.Fatalf("worker published wrong limits: %+v", state)
+	}
+
+	// Shutdown leaves state for a later command holding the lifecycle lock.
+	w.shutdown()
+	if after, err := LoadState(stateDir); err != nil || after == nil {
+		t.Fatalf("shutdown deleted state a worker cannot safely delete: (%+v, %v)", after, err)
+	}
+
+	// What must not survive shutdown is a second publication: a late
+	// readiness callback here would resurrect a share that has already
+	// handed its peers back.
+	if err := RemoveState(stateDir); err != nil {
+		t.Fatal(err)
+	}
+	w.onReady()
+	if state, err := LoadState(stateDir); err != nil || state != nil {
+		t.Fatalf("late readiness republished a stopped share: (%+v, %v)", state, err)
+	}
+}
+
+func TestWorkerDoesNotMutateWindowSize(t *testing.T) {
+	runner := newFakeRunner()
+	w, err := NewWorker(WorkerConfig{
+		SessionID:   "$1",
+		MgmtSession: "mgmt",
+		StateDir:    filepath.Join(t.TempDir(), "state"),
+		MaxViewers:  1,
+		Runner:      runner,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if err := w.Run(ctx); err != nil {
+		t.Fatal(err)
+	}
+	for _, call := range runner.calls {
+		for _, arg := range call {
+			if arg == "window-size" {
+				t.Fatalf("worker mutated tmux window sizing: %v", call)
+			}
+		}
+	}
+}
+
+func TestRoleSlots(t *testing.T) {
+	slots := newRoleSlots(2, "share is full")
+	first, _ := slots.acquire()
+	second, _ := slots.acquire()
+	if first == nil || second == nil {
+		t.Fatal("slot pool refused within its capacity")
+	}
+	if release, busy := slots.acquire(); release != nil || busy != "share is full" {
+		t.Fatalf("over-capacity acquire = (%v, %q)", release != nil, busy)
+	}
+
+	first()
+	next, _ := slots.acquire()
+	if next == nil {
+		t.Fatal("released slot was not reusable")
+	}
+	next()
+	next()
+	if a, _ := slots.acquire(); a == nil {
+		t.Fatal("slot disappeared after idempotent release")
+	}
+	if b, _ := slots.acquire(); b != nil {
+		t.Fatal("double release created an extra slot")
+	}
+}
+
+func TestSharePeerTeardownReleasesOnce(t *testing.T) {
+	var released atomic.Int32
+	p := &sharePeer{}
+	p.hold(func() { released.Add(1) })
+
+	var wins atomic.Int32
+	var wg sync.WaitGroup
+	for range 8 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if p.teardown() {
+				wins.Add(1)
+			}
+		}()
+	}
+	wg.Wait()
+	if wins.Load() != 1 || released.Load() != 1 {
+		t.Fatalf("teardown wins=%d releases=%d, want 1 each", wins.Load(), released.Load())
+	}
+	if p.hold(func() {}) {
+		t.Fatal("closed peer accepted a new reservation")
+	}
+}
+
+func TestSharePeerAdmissionRaceReturnsSlot(t *testing.T) {
+	slots := newRoleSlots(1, "full")
+	p := &sharePeer{}
+	release, _ := slots.acquire()
+	p.teardown()
+	if !p.hold(release) {
+		release()
+	}
+	if next, _ := slots.acquire(); next == nil {
+		t.Fatal("role slot leaked when the peer closed during admission")
+	}
+}
+
+func TestSharePeerEstablishmentDeadlineCanBeCanceled(t *testing.T) {
+	expired := make(chan struct{})
+	p := &sharePeer{}
+	p.armEstablishment(20*time.Millisecond, func() { close(expired) })
+	p.markEstablished()
+	select {
+	case <-expired:
+		t.Fatal("establishment deadline fired after the peer became ready")
+	case <-time.After(100 * time.Millisecond):
+	}
+	p.teardown()
+}
+
+func TestSharePeerTeardownClosesPublishedShell(t *testing.T) {
+	marker := filepath.Join(t.TempDir(), "started")
+	sh := streamtype.NewShell(nil, false)
+	sh.ForcedArgv = []string{"/bin/sh", "-c", "touch \"$0\"", marker}
+	p := &sharePeer{}
+	if !p.publish(sh, &session.Session{}) {
+		t.Fatal("live peer refused publication")
+	}
+	if !p.teardown() {
+		t.Fatal("live peer was not torn down")
+	}
+
+	stream := &workerTestStream{}
+	syn, _ := json.Marshal(map[string]any{"type": "shell"})
+	if err := sh.OnSYN(stream, syn, false); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(marker); !os.IsNotExist(err) {
+		t.Fatalf("teardown left the published handler able to execute; stat error=%v", err)
+	}
+}
+
+func TestSharePeerPublishRacesTeardown(t *testing.T) {
+	for i := 0; i < 200; i++ {
+		p := &sharePeer{}
+		sh := streamtype.NewShell(nil, false)
+		var wg sync.WaitGroup
+		var published bool
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			published = p.publish(sh, &session.Session{})
+		}()
+		go func() {
+			defer wg.Done()
+			p.teardown()
+		}()
+		wg.Wait()
+
+		p.mu.Lock()
+		installed := p.shell
+		closed := p.closed
+		p.mu.Unlock()
+		if !closed || published != (installed == sh) {
+			t.Fatalf("iteration %d: published=%v installed=%v closed=%v", i, published, installed == sh, closed)
+		}
+	}
+}
+
+type workerTestStream struct{}
+
+func (*workerTestStream) ID() uint32                   { return 1 }
+func (*workerTestStream) ConnectPath() string          { return "/" }
+func (*workerTestStream) WriteSYN([]byte) error        { return nil }
+func (*workerTestStream) WriteDAT([]byte) error        { return nil }
+func (*workerTestStream) WriteFIN([]byte) error        { return nil }
+func (*workerTestStream) SendRaw(uint16, []byte) error { return nil }
+func (*workerTestStream) BufferedAmount() uint64       { return 0 }
+
+var _ streamtype.Stream = (*workerTestStream)(nil)
+
+// A blocked peer delivery must not block the shared signaling loop.
+func TestPublishDoesNotDrainOnCallerGoroutine(t *testing.T) {
+	blocked := make(chan struct{})
+	release := make(chan struct{})
+	var once sync.Once
+
+	p := &sharePeer{}
+	p.deliver = func([]byte) {
+		once.Do(func() { close(blocked) })
+		<-release
+	}
+	defer close(release)
+
+	// A frame is already queued, so the drain has something to park on.
+	p.handleMessage([]byte("queued"))
+
+	returned := make(chan bool, 1)
+	go func() { returned <- p.publish(nil, nil) }()
+
+	select {
+	case ok := <-returned:
+		if !ok {
+			t.Fatal("publish refused on a live peer")
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("publish blocked on delivery -- the signaling loop would be stalled with it")
+	}
+
+	select {
+	case <-blocked:
+	case <-time.After(5 * time.Second):
+		t.Fatal("the queued frame was never delivered")
+	}
+}
+
+// TestDrainStopsOnTeardown: a peer that goes away mid-drain must not
+// keep feeding a session that is being torn down. Exactly one delivery
+// -- the one already in flight -- may complete; the rest of the backlog
+// must be abandoned.
+func TestDrainStopsOnTeardown(t *testing.T) {
+	const queued = 8
+	var mu sync.Mutex
+	delivered := 0
+	started := make(chan struct{}, queued)
+	proceed := make(chan struct{})
+
+	p := &sharePeer{}
+	p.deliver = func([]byte) {
+		mu.Lock()
+		delivered++
+		mu.Unlock()
+		started <- struct{}{}
+		<-proceed
+	}
+	for i := 0; i < queued; i++ {
+		p.handleMessage([]byte("frame"))
+	}
+	if !p.publish(nil, nil) {
+		t.Fatal("publish refused on a live peer")
+	}
+
+	select {
+	case <-started:
+	case <-time.After(5 * time.Second):
+		t.Fatal("drain never started")
+	}
+	p.teardown()
+	close(proceed) // release the in-flight delivery
+
+	// Wait for the drain to actually finish rather than for a duration
+	// that looks long enough. dispatching is set before the goroutine
+	// starts and cleared in its defer, so once it is false the count is
+	// final and cannot grow under a slower machine.
+	waitFor(t, "the drain goroutine to exit", func() bool {
+		p.mu.Lock()
+		defer p.mu.Unlock()
+		return !p.dispatching
+	})
+	mu.Lock()
+	got := delivered
+	mu.Unlock()
+	if got != 1 {
+		t.Errorf("delivered %d of %d queued frames after teardown, want exactly the 1 already in flight", got, queued)
+	}
+}

--- a/internal/shellweb/shellweb.go
+++ b/internal/shellweb/shellweb.go
@@ -45,11 +45,23 @@ type CapBarItem struct {
 // plain shell, or New(WithCapBar(items)) to inject a hamburger strip
 // at the top of the page (for the launcher tab in serve-all mode).
 type ShellWeb struct {
-	capBar []CapBarItem
+	capBar   []CapBarItem
+	viewOnly bool
 }
 
 // Option configures a ShellWeb at construction time.
 type Option func(*ShellWeb)
+
+// WithViewOnly serves the watch-only variant of the terminal page:
+// shell.js shows a VIEW ONLY badge, disables stdin, and never
+// transmits keystrokes or signals. This is a UX affordance; the
+// listener drops input from view peers regardless (ShellHandler.
+// ViewOnly), and the tmux client is attached read-only behind that.
+func WithViewOnly() Option {
+	return func(s *ShellWeb) {
+		s.viewOnly = true
+	}
+}
 
 // WithCapBar enables the launcher hamburger strip with the given
 // dropdown entries. The strip has no current-cap label next to the
@@ -104,6 +116,12 @@ func (s *ShellWeb) serveIndex(w http.ResponseWriter, r *http.Request) {
 	}
 
 	out := string(raw)
+	if s.viewOnly {
+		// Flag script must land before shell.js so the terminal boots
+		// straight into view mode (no input hooks to un-register).
+		out = strings.Replace(out, `<script src="shell.js"></script>`,
+			"<script>window.BB_VIEW_ONLY = true;</script>\n<script src=\"shell.js\"></script>", 1)
+	}
 	if len(s.capBar) > 0 {
 		out = strings.Replace(out, "<!-- CAP_BAR -->", renderCapBar(s.capBar), 1)
 		// Mark the body so its #terminal shrinks to leave room for the strip.

--- a/internal/shellweb/shellweb_test.go
+++ b/internal/shellweb/shellweb_test.go
@@ -1,0 +1,26 @@
+package shellweb
+
+import (
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestViewOnlyPageSetsFlagBeforeShellScript(t *testing.T) {
+	request := httptest.NewRequest("GET", "/", nil)
+
+	view := httptest.NewRecorder()
+	New(WithViewOnly()).HTTPHandler().ServeHTTP(view, request)
+	body := view.Body.String()
+	flagAt := strings.Index(body, "window.BB_VIEW_ONLY = true")
+	scriptAt := strings.Index(body, `<script src="shell.js"></script>`)
+	if flagAt < 0 || scriptAt < 0 || flagAt > scriptAt {
+		t.Fatalf("view-only flag must precede shell.js: flag=%d script=%d", flagAt, scriptAt)
+	}
+
+	control := httptest.NewRecorder()
+	New().HTTPHandler().ServeHTTP(control, request)
+	if strings.Contains(control.Body.String(), "BB_VIEW_ONLY") {
+		t.Fatal("control page included the view-only flag")
+	}
+}

--- a/internal/shellweb/static/shell.js
+++ b/internal/shellweb/static/shell.js
@@ -29,8 +29,13 @@
   const container = document.getElementById("terminal");
   container.innerHTML = ""; // clear loading message
 
+  // View mode disables input in the UI. The device enforces the same role;
+  // resize remains enabled so the remote PTY matches this viewport.
+  const viewOnly = !!window.BB_VIEW_ONLY;
+
   const term = new Terminal({
-    cursorBlink: true,
+    cursorBlink: !viewOnly,
+    disableStdin: viewOnly,
     fontFamily: 'Menlo, Monaco, "DejaVu Sans Mono", monospace',
     fontSize: 15,
     // Heavier stems so 1px-thin glyph features don't get antialiased away
@@ -63,9 +68,20 @@
   const TAG_SIGNAL = 3;
   const TAG_RESIZE = 4;
 
+  if (viewOnly) {
+    const badge = document.createElement("div");
+    badge.textContent = "VIEW ONLY";
+    badge.style.cssText =
+      "position:fixed;top:6px;right:10px;z-index:100;" +
+      "padding:2px 8px;border-radius:3px;background:#333;color:#bbb;" +
+      'font-family:-apple-system,"Segoe UI",Roboto,sans-serif;' +
+      "font-size:11px;letter-spacing:1px;pointer-events:none;";
+    document.body.appendChild(badge);
+  }
+
   ws.onopen = () => {
     fit.fit(); // recompute size now that the WS is up
-    term.focus();
+    if (!viewOnly) term.focus();
   };
 
   // Inbound bytes from the device: [tag][payload]. bootstrap.js
@@ -123,6 +139,7 @@
 
   // User keystrokes → stdin bytes, prefixed with the stdin tag.
   term.onData((data) => {
+    if (viewOnly) return;
     if (ws.readyState !== WebSocket.OPEN) return;
     const stdinBytes = new TextEncoder().encode(data);
     const buf = new Uint8Array(1 + stdinBytes.length);
@@ -144,5 +161,7 @@
   // Window resize → fit, which triggers term.onResize above.
   window.addEventListener("resize", () => fit.fit());
 
-  container.addEventListener("click", () => term.focus());
+  if (!viewOnly) {
+    container.addEventListener("click", () => term.focus());
+  }
 })();

--- a/internal/signaling/client.go
+++ b/internal/signaling/client.go
@@ -6,10 +6,13 @@
 package signaling
 
 import (
+	"context"
 	"crypto/tls"
+	"errors"
 	"fmt"
 	"log"
 	"os"
+	"strings"
 	"sync"
 	"time"
 
@@ -22,6 +25,9 @@ import (
 
 // Message is a generic signaling message.
 type Message map[string]interface{}
+
+// ErrPreempted means the server accepted another registration for this UID.
+var ErrPreempted = errors.New("signaling registration was preempted")
 
 // Client manages the WebSocket connection to the signaling server.
 type Client struct {
@@ -64,7 +70,10 @@ type Client struct {
 	// instances racing for the same UID would ping-pong forever.
 	OnPreempted func()
 
-	conn *websocket.Conn
+	ctx    context.Context
+	cancel context.CancelFunc
+	connMu sync.RWMutex
+	conn   *websocket.Conn
 
 	// writeMu serializes WriteJSON. gorilla/websocket forbids concurrent
 	// writes, and we write from both the message-handler goroutine (offers)
@@ -83,11 +92,14 @@ type Client struct {
 // can replace before calling Connect to override.
 func NewClient(server string, id *identity.Identity) *Client {
 	ws := fmt.Sprintf("wss://%s/ws/device/%s", server, id.UID)
+	ctx, cancel := context.WithCancel(context.Background())
 	return &Client{
 		ID:          id,
 		Server:      server,
 		ServerWS:    ws,
 		OnPreempted: defaultOnPreempted,
+		ctx:         ctx,
+		cancel:      cancel,
 	}
 }
 
@@ -101,7 +113,7 @@ func defaultOnPreempted() {
 }
 
 // URL returns the canonical user-facing URL for this device:
-// ``https://<server>/<uid>#<code>[!<flags>]``. Single source of truth — all
+// "https://<server>/<uid>#<code>[!<flags>]". All
 // consumers (CLI banners, reconnect prints, downstream wrappers) should
 // read this rather than reconstruct it from Server/ID.UID/ID.Code, since
 // the exact shape (fragment placement, flag syntax) is the protocol's
@@ -110,18 +122,35 @@ func defaultOnPreempted() {
 // browsers don't transmit fragments. Grammar and flag list live in
 // CONVENTIONS.md.
 func (c *Client) URL(debug bool) string {
-	s := "https://" + c.Server + "/" + c.ID.UID + "#" + c.ID.Code
 	if debug {
-		s += "!debug"
+		return c.CodeURL(c.ID.Code, "debug")
+	}
+	return c.CodeURL(c.ID.Code)
+}
+
+// CodeURL composes a device URL carrying an explicit access code and
+// fragment flags. Listeners that issue more than one code per identity
+// (bitbang share: control + view) use it directly; URL is the
+// single-code case.
+//
+// Flags are named bare ("ephemeral", "debug") or as "name=value"; the
+// grammar uses one "!" followed by a comma-separated list, as defined by
+// CONVENTIONS.md and bootstrap.js's parseUrlFlags. Keeping it here means no
+// caller has to reproduce it:
+//
+//	https://<server>/<uid>#<code>[!<flag>[,<flag>]*]
+func (c *Client) CodeURL(code string, flags ...string) string {
+	s := "https://" + c.Server + "/" + c.ID.UID + "#" + code
+	if len(flags) > 0 {
+		s += "!" + strings.Join(flags, ",")
 	}
 	return s
 }
 
 // Connect connects to the signaling server and registers. On success, it
-// calls handler for each incoming message. Reconnects automatically on
-// disconnection — unless the server reports another instance has
-// preempted us, in which case it returns and stays returned.
-func (c *Client) Connect(handler func(msg Message)) {
+// calls handler for each incoming message. It reconnects automatically until
+// Stop is called or another instance preempts this registration.
+func (c *Client) Connect(handler func(msg Message)) error {
 	for {
 		err := c.connectOnce(handler)
 		if c.preempted {
@@ -129,11 +158,20 @@ func (c *Client) Connect(handler func(msg Message)) {
 			// would just kick them out and trigger their reconnect, ad
 			// infinitum. The OnPreempted callback has already fired
 			// inside the message loop; nothing more to do here.
-			return
+			return ErrPreempted
+		}
+		if c.ctx.Err() != nil {
+			return nil
 		}
 		if err != nil {
 			log.Printf("Connection lost: %v, retrying in 3s...", err)
-			time.Sleep(3 * time.Second)
+			timer := time.NewTimer(3 * time.Second)
+			select {
+			case <-timer.C:
+			case <-c.ctx.Done():
+				timer.Stop()
+				return nil
+			}
 		}
 	}
 }
@@ -147,15 +185,29 @@ func (c *Client) connectOnce(handler func(msg Message)) error {
 		TLSClientConfig:  &tls.Config{InsecureSkipVerify: true},
 		HandshakeTimeout: 10 * time.Second,
 	}
-	conn, _, err := dialer.Dial(c.ServerWS, nil)
+	conn, _, err := dialer.DialContext(c.ctx, c.ServerWS, nil)
 	if err != nil {
 		return fmt.Errorf("dial: %w", err)
 	}
-	defer conn.Close()
+	c.connMu.Lock()
+	if c.ctx.Err() != nil {
+		c.connMu.Unlock()
+		_ = conn.Close()
+		return c.ctx.Err()
+	}
 	c.conn = conn
+	c.connMu.Unlock()
+	defer func() {
+		c.connMu.Lock()
+		if c.conn == conn {
+			c.conn = nil
+		}
+		c.connMu.Unlock()
+		_ = conn.Close()
+	}()
 
 	// Register
-	if err := c.register(); err != nil {
+	if err := c.register(conn); err != nil {
 		return fmt.Errorf("register: %w", err)
 	}
 	// Single-word post-register marker so a watcher (test harness, log
@@ -198,15 +250,30 @@ func (c *Client) connectOnce(handler func(msg Message)) error {
 
 // Send sends a JSON message to the signaling server.
 func (c *Client) Send(msg Message) error {
-	if c.conn == nil {
+	c.connMu.RLock()
+	conn := c.conn
+	c.connMu.RUnlock()
+	if conn == nil {
 		return fmt.Errorf("not connected")
 	}
 	c.writeMu.Lock()
 	defer c.writeMu.Unlock()
-	return c.conn.WriteJSON(msg)
+	return conn.WriteJSON(msg)
 }
 
-func (c *Client) register() error {
+// Stop interrupts an active connection or reconnect delay. It is safe to call
+// more than once.
+func (c *Client) Stop() {
+	c.cancel()
+	c.connMu.RLock()
+	conn := c.conn
+	c.connMu.RUnlock()
+	if conn != nil {
+		_ = conn.Close()
+	}
+}
+
+func (c *Client) register(conn *websocket.Conn) error {
 	// Send registration with public key and protocol version. want_code is
 	// additive in v3.x — the server returns a 6-digit code in the
 	// registered reply when both we set it and the server has the pairing
@@ -222,14 +289,14 @@ func (c *Client) register() error {
 		reg["want_code"] = true
 	}
 	c.writeMu.Lock()
-	err := c.conn.WriteJSON(reg)
+	err := conn.WriteJSON(reg)
 	c.writeMu.Unlock()
 	if err != nil {
 		return fmt.Errorf("send register: %w", err)
 	}
 
 	var msg Message
-	if err := c.conn.ReadJSON(&msg); err != nil {
+	if err := conn.ReadJSON(&msg); err != nil {
 		return fmt.Errorf("read: %w", err)
 	}
 

--- a/internal/signaling/client_stop_test.go
+++ b/internal/signaling/client_stop_test.go
@@ -1,0 +1,27 @@
+package signaling
+
+import (
+	"testing"
+	"time"
+)
+
+func TestStopInterruptsReconnect(t *testing.T) {
+	c := testClient(t)
+	c.ServerWS = "ws://127.0.0.1:1"
+
+	done := make(chan struct{})
+	go func() {
+		c.Connect(func(Message) {})
+		close(done)
+	}()
+
+	time.Sleep(20 * time.Millisecond)
+	c.Stop()
+	c.Stop()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("Connect did not stop during its reconnect delay")
+	}
+}

--- a/internal/signaling/fragment.go
+++ b/internal/signaling/fragment.go
@@ -1,0 +1,43 @@
+package signaling
+
+import "strings"
+
+// ParseFragment splits the access code and comma-separated flags used by the
+// browser URL grammar. An optional embedded device URL begins at the first
+// slash after the flag opener.
+func ParseFragment(fragment string) (code string, flags []string) {
+	i := 0
+	for i < len(fragment) && isCodeByte(fragment[i]) {
+		i++
+	}
+	code = fragment[:i]
+	if i >= len(fragment) || fragment[i] != '!' {
+		return code, nil
+	}
+
+	end := i + 1
+	for end < len(fragment) && fragment[end] != '/' {
+		end++
+	}
+	for _, flag := range strings.Split(fragment[i+1:end], ",") {
+		if flag != "" {
+			flags = append(flags, flag)
+		}
+	}
+	return code, flags
+}
+
+func isCodeByte(b byte) bool {
+	return b >= 'A' && b <= 'Z' || b >= 'a' && b <= 'z' ||
+		b >= '0' && b <= '9' || b == '_' || b == '-'
+}
+
+// HasFlag reports whether want is present, ignoring an optional value.
+func HasFlag(flags []string, want string) bool {
+	for _, flag := range flags {
+		if name, _, _ := strings.Cut(flag, "="); name == want {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/signaling/fragment_test.go
+++ b/internal/signaling/fragment_test.go
@@ -1,0 +1,36 @@
+package signaling
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestParseFragment(t *testing.T) {
+	tests := []struct {
+		fragment  string
+		wantCode  string
+		wantFlags []string
+	}{
+		{"ABC123", "ABC123", nil},
+		{"ABC123!ephemeral", "ABC123", []string{"ephemeral"}},
+		{"ABC123!ephemeral,debug", "ABC123", []string{"ephemeral", "debug"}},
+		{"ABC123!msg_timeout=5,ephemeral", "ABC123", []string{"msg_timeout=5", "ephemeral"}},
+		{"ABC123!ephemeral,debug/https://nas.local", "ABC123", []string{"ephemeral", "debug"}},
+		{"ABC123/https://nas.local", "ABC123", nil},
+		{"ABC123!,,", "ABC123", nil},
+		{"", "", nil},
+	}
+	for _, tc := range tests {
+		code, flags := ParseFragment(tc.fragment)
+		if code != tc.wantCode || !reflect.DeepEqual(flags, tc.wantFlags) {
+			t.Errorf("ParseFragment(%q) = (%q, %v), want (%q, %v)", tc.fragment, code, flags, tc.wantCode, tc.wantFlags)
+		}
+	}
+}
+
+func TestHasFlagIgnoresValue(t *testing.T) {
+	flags := []string{"debug", "msg_timeout=5", "ephemeral"}
+	if !HasFlag(flags, "msg_timeout") || !HasFlag(flags, "ephemeral") || HasFlag(flags, "relay") {
+		t.Fatalf("HasFlag returned unexpected results for %v", flags)
+	}
+}

--- a/internal/signaling/url_test.go
+++ b/internal/signaling/url_test.go
@@ -1,0 +1,80 @@
+package signaling
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/richlegrand/bitbang/internal/identity"
+)
+
+func testClient(t *testing.T) *Client {
+	t.Helper()
+	id, err := identity.Load("bitbang-url-test", true)
+	if err != nil {
+		t.Fatalf("identity.Load: %v", err)
+	}
+	return NewClient("bitba.ng", id)
+}
+
+// TestCodeURLGrammar pins URL composition to the fragment grammar in
+// CONVENTIONS.md, which bootstrap.js implements:
+//
+//	<code> [ '!' <flag> [ ',' <flag> ]* ] [ '/' <device-URL> ]
+//
+// One "!" opens the flag list and COMMAS separate the flags. Emitting
+// "!a!b" instead would leave the browser -- and ParseFragment on the CLI
+// side -- reading a single flag named "a!b".
+func TestCodeURLGrammar(t *testing.T) {
+	c := testClient(t)
+
+	tests := []struct {
+		flags []string
+		want  string
+	}{
+		{nil, "#" + c.ID.Code},
+		{[]string{"ephemeral"}, "#" + c.ID.Code + "!ephemeral"},
+		{[]string{"ephemeral", "debug"}, "#" + c.ID.Code + "!ephemeral,debug"},
+		{[]string{"a", "b", "c"}, "#" + c.ID.Code + "!a,b,c"},
+	}
+	for _, tc := range tests {
+		got := c.CodeURL(c.ID.Code, tc.flags...)
+		if !strings.HasSuffix(got, tc.want) {
+			t.Errorf("CodeURL(%v) = %q, want fragment %q", tc.flags, got, tc.want)
+		}
+		if !strings.HasPrefix(got, "https://bitba.ng/"+c.ID.UID+"#") {
+			t.Errorf("CodeURL(%v) = %q, want the canonical https://<server>/<uid>#... shape", tc.flags, got)
+		}
+		// Exactly one "!" -- the flag list opener, never a separator.
+		if n := strings.Count(got, "!"); n > 1 {
+			t.Errorf("CodeURL(%v) = %q has %d '!' separators, want at most 1", tc.flags, got, n)
+		}
+	}
+}
+
+// TestCodeURLCarriesGivenCode: a share's view URL must carry the view
+// code, not the identity's own -- that distinction is the whole
+// two-credential model.
+func TestCodeURLCarriesGivenCode(t *testing.T) {
+	c := testClient(t)
+	const viewCode = "VIEWCODE123"
+
+	got := c.CodeURL(viewCode, "ephemeral")
+	if !strings.HasSuffix(got, "#"+viewCode+"!ephemeral") {
+		t.Errorf("CodeURL = %q, want it to carry %q", got, viewCode)
+	}
+	if strings.Contains(got, c.ID.Code) {
+		t.Errorf("CodeURL = %q leaked the identity's own access code", got)
+	}
+}
+
+// TestURLUsesCodeURL keeps the single-code path on the same composer,
+// so the grammar can only ever be defined in one place.
+func TestURLUsesCodeURL(t *testing.T) {
+	c := testClient(t)
+	if got, want := c.URL(false), c.CodeURL(c.ID.Code); got != want {
+		t.Errorf("URL(false) = %q, want %q", got, want)
+	}
+	if got, want := c.URL(true), c.CodeURL(c.ID.Code, "debug"); got != want {
+		t.Errorf("URL(true) = %q, want %q", got, want)
+	}
+}

--- a/internal/streamtype/shell.go
+++ b/internal/streamtype/shell.go
@@ -236,10 +236,26 @@ type ShellHandler struct {
 	// /bin/bash`). Empty means "use $SHELL, or /bin/sh if unset."
 	DefaultArgv []string
 
-	// ForcedArgv, if non-nil, locks every connection to this exact
-	// argv. Set by `bitbang run` for service-style listeners that
-	// expose only one command. Client-supplied argv is ignored.
+	// ForcedArgv, when non-empty, locks every connection to this exact
+	// command. It also ignores client-supplied argv, environment, and cwd.
 	ForcedArgv []string
+
+	// ForcedEnv is the environment used verbatim when ForcedArgv is
+	// set. Nil means "inherit the listener's own environment". Ignored
+	// when ForcedArgv is empty.
+	ForcedEnv []string
+
+	// ViewOnly drops stdin, signals, and stdin EOF. Resize remains enabled
+	// so the remote PTY matches the viewer's terminal. Command-level
+	// restrictions, such as tmux attach -r, provide a second boundary.
+	ViewOnly bool
+
+	// AcquireSlot, if non-nil, replaces the process-wide MaxConcurrent
+	// gate with a caller-owned admission policy (bitbang share: one
+	// controller slot, N viewer slots). Return a non-nil release func
+	// to admit the stream. It is called exactly once when the stream
+	// finishes. Return nil plus a client-facing message to refuse it.
+	AcquireSlot func() (release func(), errMsg string)
 
 	// MaxConcurrent caps the number of simultaneously-active shell
 	// streams across the whole process (not per-session). 0 = no
@@ -260,6 +276,7 @@ type ShellHandler struct {
 
 	mu                 sync.Mutex
 	streams            map[uint32]*shellSession
+	closed             bool
 	outputDrainTimeout time.Duration
 }
 
@@ -275,6 +292,7 @@ type shellSession struct {
 	ptyFile ptylib.Pty     // PTY mode: master side, used for read + write
 	stdin   io.WriteCloser // pipe mode: dedicated stdin pipe
 	output  *shellOutput   // drain output before FIN and terminal close
+	done    chan struct{}
 }
 
 func (s *shellSession) wait() error {
@@ -333,19 +351,16 @@ func NewShell(defaultArgv []string, verbose bool) *ShellHandler {
 func (h *ShellHandler) Type() string             { return "shell" }
 func (h *ShellHandler) OnConnect(_ string) error { return nil }
 
-// KillAll sends SIGHUP to every active shell process this handler is
-// tracking. Called by the listener wire-up when the underlying data
-// channel closes — without it, processes outlive the connection,
-// keep holding their max-sessions slot, and the next connector hits
-// "listener is busy."
-//
-// SIGHUP is the conventional "your terminal went away" signal. bash
-// and most shells exit cleanly on it. The actual cleanup (FIN
-// emission, slot release, map removal) still flows through
-// waitAndFinish — that goroutine unblocks once cmd.Wait sees the
-// process exit.
-func (h *ShellHandler) KillAll() {
+// Close prevents future spawns and terminates every active process. It first
+// requests platform-appropriate termination, then force-kills after a bounded
+// grace period. The lock covers process start and registration.
+func (h *ShellHandler) Close() {
 	h.mu.Lock()
+	if h.closed {
+		h.mu.Unlock()
+		return
+	}
+	h.closed = true
 	sessions := make([]*shellSession, 0, len(h.streams))
 	for _, sess := range h.streams {
 		sessions = append(sessions, sess)
@@ -354,6 +369,35 @@ func (h *ShellHandler) KillAll() {
 	for _, sess := range sessions {
 		if sess.process != nil {
 			_ = terminateShellProcess(sess.process)
+		}
+	}
+	if len(sessions) == 0 {
+		return
+	}
+
+	grace := time.NewTimer(2 * time.Second)
+	defer grace.Stop()
+	for i, sess := range sessions {
+		select {
+		case <-sess.done:
+		case <-grace.C:
+			// A process may ignore SIGHUP. Do not let it retain a shell or
+			// admission slot after its connection is gone.
+			for _, remaining := range sessions[i:] {
+				if remaining.process != nil {
+					_ = remaining.process.Kill()
+				}
+			}
+			killWait := time.NewTimer(time.Second)
+			defer killWait.Stop()
+			for _, remaining := range sessions[i:] {
+				select {
+				case <-remaining.done:
+				case <-killWait.C:
+					return
+				}
+			}
+			return
 		}
 	}
 }
@@ -378,30 +422,39 @@ func (h *ShellHandler) OnSYN(s Stream, payload []byte, final bool) error {
 		return nil
 	}
 
-	// Max-concurrent gate. Atomic check-then-increment with rollback
-	// if we lose the race; on the happy path waitAndFinish decrements.
-	// slotTaken tracks whether we own a slot that still needs
-	// releasing; the defer below releases it on any early-return path
-	// (spawn failed, bad config, …) but we clear slotTaken once
-	// waitAndFinish is launched and assumes ownership.
-	slotTaken := false
-	if h.MaxConcurrent > 0 {
+	// Admission gate. AcquireSlot (caller-owned policy) wins when set;
+	// otherwise the process-wide MaxConcurrent atomic. Either way,
+	// `release` owns the slot: the defer below releases it on any
+	// early-return path (spawn failed or bad config) and is cleared
+	// once waitAndFinish is launched and assumes ownership.
+	var release func()
+	if h.AcquireSlot != nil {
+		rel, errMsg := h.AcquireSlot()
+		if rel == nil {
+			log.Printf("Shell rejected: %s", errMsg)
+			h.sendShellError(s, errMsg)
+			return nil
+		}
+		release = rel
+	} else if h.MaxConcurrent > 0 {
 		if int(activeShellCount.Add(1)) > h.MaxConcurrent {
 			activeShellCount.Add(-1)
 			log.Printf("Shell rejected: at max-sessions=%d", h.MaxConcurrent)
 			h.sendShellError(s, fmt.Sprintf("listener is busy (max %d concurrent shell session(s))", h.MaxConcurrent))
 			return nil
 		}
-		slotTaken = true
+		release = func() { activeShellCount.Add(-1) }
 	}
+	deferredRelease := release
 	defer func() {
-		if slotTaken {
-			activeShellCount.Add(-1)
+		if deferredRelease != nil {
+			deferredRelease()
 		}
 	}()
 
 	// Resolve argv: restricted-mode ours, otherwise client's, otherwise
 	// default, otherwise $SHELL, otherwise /bin/sh.
+	restricted := len(h.ForcedArgv) > 0
 	argv := h.ForcedArgv
 	if len(argv) == 0 {
 		argv = open.Argv
@@ -414,12 +467,23 @@ func (h *ShellHandler) OnSYN(s Stream, payload []byte, final bool) error {
 	}
 
 	cmd := exec.Command(argv[0], argv[1:]...)
-	cmd.Env = os.Environ()
-	for k, v := range open.Env {
-		cmd.Env = append(cmd.Env, k+"="+v)
-	}
-	if open.Cwd != "" {
-		cmd.Dir = open.Cwd
+	if restricted {
+		// Forced argv forces the whole spawn: the client's env and cwd
+		// are ignored, or a connector could still steer the pinned
+		// command via PATH, loader variables, or its working directory.
+		if h.ForcedEnv != nil {
+			cmd.Env = h.ForcedEnv
+		} else {
+			cmd.Env = os.Environ()
+		}
+	} else {
+		cmd.Env = os.Environ()
+		for k, v := range open.Env {
+			cmd.Env = append(cmd.Env, k+"="+v)
+		}
+		if open.Cwd != "" {
+			cmd.Dir = open.Cwd
+		}
 	}
 
 	// Defaults: PTY off if the client didn't set it (non-interactive is
@@ -433,8 +497,23 @@ func (h *ShellHandler) OnSYN(s Stream, payload []byte, final bool) error {
 		rows = 24
 	}
 
-	sess := &shellSession{output: newShellOutput()}
+	sess := &shellSession{output: newShellOutput(), done: make(chan struct{})}
 	var stdout, stderr io.Reader
+
+	// Starting and publishing a process is one operation with respect to
+	// Close. If Close wins this lock, no command is executed; if OnSYN wins,
+	// the process is registered before Close can take its snapshot.
+	h.mu.Lock()
+	if h.closed {
+		h.mu.Unlock()
+		h.sendShellError(s, "connection is closed")
+		return nil
+	}
+	if h.streams[s.ID()] != nil {
+		h.mu.Unlock()
+		h.sendShellError(s, "a shell is already open on this stream")
+		return nil
+	}
 
 	ptyMode := open.PTY && platformSupportsPTY
 	if ptyMode {
@@ -443,11 +522,13 @@ func (h *ShellHandler) OnSYN(s Stream, payload []byte, final bool) error {
 		// reads passwords with echo off, etc.
 		terminal, err := ptylib.New()
 		if err != nil {
+			h.mu.Unlock()
 			h.sendShellError(s, "pty failed: "+err.Error())
 			return nil
 		}
 		if err := terminal.Resize(cols, rows); err != nil {
 			_ = terminal.Close()
+			h.mu.Unlock()
 			h.sendShellError(s, "pty resize failed: "+err.Error())
 			return nil
 		}
@@ -456,6 +537,7 @@ func (h *ShellHandler) OnSYN(s Stream, payload []byte, final bool) error {
 		ptyCmd.Dir = cmd.Dir
 		if err := ptyCmd.Start(); err != nil {
 			_ = terminal.Close()
+			h.mu.Unlock()
 			h.sendShellError(s, "spawn failed: "+err.Error())
 			return nil
 		}
@@ -469,23 +551,31 @@ func (h *ShellHandler) OnSYN(s Stream, payload []byte, final bool) error {
 		// `bitbang connect URL -- ls /var/log`).
 		sin, err := cmd.StdinPipe()
 		if err != nil {
+			h.mu.Unlock()
 			h.sendShellError(s, "stdin pipe: "+err.Error())
 			return nil
 		}
 		sout, err := cmd.StdoutPipe()
 		if err != nil {
 			_ = sin.Close()
+			h.mu.Unlock()
 			h.sendShellError(s, "stdout pipe: "+err.Error())
 			return nil
 		}
 		serr, err := cmd.StderrPipe()
 		if err != nil {
 			_ = sin.Close()
+			h.mu.Unlock()
 			h.sendShellError(s, "stderr pipe: "+err.Error())
 			return nil
 		}
 		if err := cmd.Start(); err != nil {
+			// Wait never runs, so the parent ends of the pipes are
+			// ours to close.
 			_ = sin.Close()
+			_ = sout.Close()
+			_ = serr.Close()
+			h.mu.Unlock()
 			h.sendShellError(s, "spawn failed: "+err.Error())
 			return nil
 		}
@@ -496,7 +586,6 @@ func (h *ShellHandler) OnSYN(s Stream, payload []byte, final bool) error {
 		stderr = serr
 	}
 
-	h.mu.Lock()
 	h.streams[s.ID()] = sess
 	h.mu.Unlock()
 
@@ -504,9 +593,9 @@ func (h *ShellHandler) OnSYN(s Stream, payload []byte, final bool) error {
 
 	// Spin up the output pumps and the wait/FIN goroutine. Each runs
 	// independently; the wait goroutine cleans up shared state and
-	// releases the max-concurrent slot. We clear slotTaken here so
+	// releases the admission slot. We clear deferredRelease here so
 	// the local defer doesn't double-release.
-	slotTaken = false
+	deferredRelease = nil
 	sess.output.Add(1)
 	go func() {
 		defer sess.output.Done()
@@ -519,9 +608,9 @@ func (h *ShellHandler) OnSYN(s Stream, payload []byte, final bool) error {
 			h.pumpReader(s, stderr, shellTagStderr, sess.output.cancelled())
 		}()
 	}
-	go h.waitAndFinish(s, sess, argv, h.MaxConcurrent > 0)
+	go h.waitAndFinish(s, sess, argv, release)
 
-	if final {
+	if final && !h.ViewOnly {
 		// SYN|FIN means the client won't send any stdin. For pipe mode
 		// we close the stdin pipe so the process sees EOF; for PTY mode
 		// the process gets nothing on the input fd but the master stays
@@ -606,12 +695,18 @@ func (h *ShellHandler) OnDAT(s Stream, payload []byte) error {
 
 	switch tag {
 	case shellTagStdin:
+		if h.ViewOnly {
+			return nil
+		}
 		sess.writeInput(body)
 	case shellTagSignal:
 		// In PTY mode, Ctrl-C usually arrives as byte 0x03 in stdin and
 		// the kernel converts it to SIGINT — this explicit path is
 		// mostly for non-PTY clients and for signals that don't map to
 		// a control character (SIGHUP, SIGUSR1, etc.).
+		if h.ViewOnly {
+			return nil
+		}
 		if sig := signalFromName(string(body)); sig != nil && sess.process != nil {
 			_ = sess.process.Signal(sig)
 		}
@@ -628,8 +723,12 @@ func (h *ShellHandler) OnDAT(s Stream, payload []byte) error {
 
 // OnFIN closes the process's stdin (signaling EOF for non-interactive
 // commands like `cat` to finish). The process exit is tracked
-// separately by waitAndFinish.
+// separately by waitAndFinish. View-only peers get no stdin-EOF side
+// effect either; their FIN is just "stopped watching".
 func (h *ShellHandler) OnFIN(s Stream, _ []byte) error {
+	if h.ViewOnly {
+		return nil
+	}
 	h.closeStdin(s.ID())
 	return nil
 }
@@ -659,14 +758,14 @@ func (h *ShellHandler) detachSession(streamID uint32, running *shellSession) pty
 
 // waitAndFinish blocks on cmd.Wait(), then emits the FIN trailer with
 // the exit code and any terminating signal. Also cleans up per-stream
-// state (PTY fd, map entry) and — if releaseSlot is true — releases
-// the max-concurrent slot that OnSYN reserved.
-func (h *ShellHandler) waitAndFinish(s Stream, running *shellSession, argv []string, releaseSlot bool) {
+// state and releases the admission slot reserved by OnSYN.
+func (h *ShellHandler) waitAndFinish(s Stream, running *shellSession, argv []string, release func()) {
 	err := running.wait()
 	terminal := h.detachSession(s.ID(), running)
-	if releaseSlot {
-		activeShellCount.Add(-1)
+	if release != nil {
+		release()
 	}
+	close(running.done)
 
 	// Process exit and output EOF are separate events. Platform-specific PTY
 	// shutdown drains the final bytes before FIN closes the browser stream.

--- a/internal/streamtype/shell.go
+++ b/internal/streamtype/shell.go
@@ -245,9 +245,16 @@ type ShellHandler struct {
 	// when ForcedArgv is empty.
 	ForcedEnv []string
 
-	// ViewOnly drops stdin, signals, and stdin EOF. Resize remains enabled
-	// so the remote PTY matches the viewer's terminal. Command-level
-	// restrictions, such as tmux attach -r, provide a second boundary.
+	// ViewOnly drops stdin, signals, and stdin EOF at the transport layer.
+	// Resize stays enabled so each viewer's own PTY matches their terminal;
+	// that is per-peer and only becomes a shared-state question when peers
+	// attach to one terminal (bitbang share). There the cross-peer guarantee
+	// is tmux's, not ours: viewers attach with `tmux attach -r`, which since
+	// tmux 3.2 is an alias for read-only,ignore-size, and ignore-size means a
+	// client cannot affect the size of other clients. The >= 3.2 floor is
+	// enforced by share.CheckVersion (wired at cmd/bitbang/share.go), so -r
+	// always carries ignore-size. Pinned by TestViewerAttachesReadOnly and
+	// TestViewerCannotResizeWhileControlAttached.
 	ViewOnly bool
 
 	// AcquireSlot, if non-nil, replaces the process-wide MaxConcurrent

--- a/internal/streamtype/shell_lifecycle_test.go
+++ b/internal/streamtype/shell_lifecycle_test.go
@@ -115,7 +115,7 @@ func TestWaitAndFinishBackpressureStillCompletesSession(t *testing.T) {
 	h := NewShell(nil, false)
 	h.outputDrainTimeout = 20 * time.Millisecond
 	terminal := &synchronizedLifecyclePTY{}
-	sess := &shellSession{cmd: cmd, process: cmd.Process, ptyFile: terminal, output: output}
+	sess := &shellSession{cmd: cmd, process: cmd.Process, ptyFile: terminal, output: output, done: make(chan struct{})}
 	h.streams[stream.id] = sess
 	previousActive := activeShellCount.Swap(1)
 	defer activeShellCount.Store(previousActive)
@@ -124,7 +124,7 @@ func TestWaitAndFinishBackpressureStillCompletesSession(t *testing.T) {
 		defer output.Done()
 		h.pumpReader(stream, strings.NewReader("blocked"), shellTagStdout, output.cancelled())
 	}()
-	go h.waitAndFinish(stream, sess, []string{"helper"}, true)
+	go h.waitAndFinish(stream, sess, []string{"helper"}, func() { activeShellCount.Add(-1) })
 
 	select {
 	case <-stream.fin:

--- a/internal/streamtype/shell_restricted_test.go
+++ b/internal/streamtype/shell_restricted_test.go
@@ -1,0 +1,475 @@
+package streamtype
+
+import (
+	"encoding/binary"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	ptylib "github.com/aymanbagabas/go-pty"
+	"github.com/creack/pty"
+)
+
+// shellCapture is a Stream that records everything a handler writes,
+// so tests can assert on the process's output without a data channel.
+type shellCapture struct {
+	id  uint32
+	mu  sync.Mutex
+	dat [][]byte
+	syn [][]byte
+	fin [][]byte
+	// finished closes when the handler emits FIN (process exited).
+	finished chan struct{}
+	once     sync.Once
+}
+
+func newShellCapture() *shellCapture {
+	return &shellCapture{id: 1, finished: make(chan struct{})}
+}
+
+func (c *shellCapture) ID() uint32          { return c.id }
+func (c *shellCapture) ConnectPath() string { return "/" }
+func (c *shellCapture) WriteSYN(p []byte) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.syn = append(c.syn, append([]byte(nil), p...))
+	return nil
+}
+func (c *shellCapture) WriteDAT(p []byte) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.dat = append(c.dat, append([]byte(nil), p...))
+	return nil
+}
+func (c *shellCapture) WriteFIN(p []byte) error {
+	c.mu.Lock()
+	c.fin = append(c.fin, append([]byte(nil), p...))
+	c.mu.Unlock()
+	c.once.Do(func() { close(c.finished) })
+	return nil
+}
+func (c *shellCapture) SendRaw(_ uint16, p []byte) error { return c.WriteDAT(p) }
+func (c *shellCapture) BufferedAmount() uint64           { return 0 }
+
+// stdout returns everything the handler pumped with the stdout tag.
+func (c *shellCapture) stdout() string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	var b strings.Builder
+	for _, f := range c.dat {
+		if len(f) > 0 && f[0] == shellTagStdout {
+			b.Write(f[1:])
+		}
+	}
+	return b.String()
+}
+
+func (c *shellCapture) firstSYN() map[string]string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if len(c.syn) == 0 {
+		return nil
+	}
+	var m map[string]string
+	_ = json.Unmarshal(c.syn[0], &m)
+	return m
+}
+
+func (c *shellCapture) waitFinished(t *testing.T) {
+	t.Helper()
+	select {
+	case <-c.finished:
+	case <-time.After(10 * time.Second):
+		t.Fatal("timed out waiting for the process to exit")
+	}
+}
+
+func skipIfWindows(t *testing.T) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX shell semantics required")
+	}
+}
+
+// TestForcedArgvIgnoresClientArgv is the core of the `bitbang share`
+// boundary: a peer pinned to a command must not be able to run
+// anything else, no matter what it asks for.
+func TestForcedArgvIgnoresClientArgv(t *testing.T) {
+	skipIfWindows(t)
+	h := NewShell(nil, false)
+	h.ForcedArgv = []string{"/bin/echo", "forced"}
+
+	s := newShellCapture()
+	syn, _ := json.Marshal(shellOpen{
+		Type: "shell",
+		Argv: []string{"/bin/echo", "ATTACKER"},
+	})
+	if err := h.OnSYN(s, syn, false); err != nil {
+		t.Fatalf("OnSYN: %v", err)
+	}
+	s.waitFinished(t)
+
+	out := s.stdout()
+	if !strings.Contains(out, "forced") {
+		t.Errorf("output %q does not contain the forced command's output", out)
+	}
+	if strings.Contains(out, "ATTACKER") {
+		t.Errorf("client-supplied argv was executed: %q", out)
+	}
+}
+
+// TestForcedArgvIgnoresClientEnvAndCwd covers the subtler half: even
+// with argv pinned, honoring client env or cwd would let a connector
+// steer the pinned command (PATH, loader variables, working dir).
+func TestForcedArgvIgnoresClientEnvAndCwd(t *testing.T) {
+	skipIfWindows(t)
+	tmp := t.TempDir()
+
+	h := NewShell(nil, false)
+	h.ForcedArgv = []string{"/bin/sh", "-c", "echo INJECTED=${INJECTED:-none}; pwd"}
+	h.ForcedEnv = []string{"PATH=/usr/bin:/bin", "HOME=" + tmp}
+
+	s := newShellCapture()
+	syn, _ := json.Marshal(shellOpen{
+		Type: "shell",
+		Env:  map[string]string{"INJECTED": "yes", "LD_PRELOAD": "/tmp/evil.so"},
+		Cwd:  tmp,
+	})
+	if err := h.OnSYN(s, syn, false); err != nil {
+		t.Fatalf("OnSYN: %v", err)
+	}
+	s.waitFinished(t)
+
+	out := s.stdout()
+	if strings.Contains(out, "INJECTED=yes") {
+		t.Errorf("client env reached the forced process: %q", out)
+	}
+	if !strings.Contains(out, "INJECTED=none") {
+		t.Errorf("expected the forced environment, got %q", out)
+	}
+	// cwd should be the listener's, not the client's request. Compare
+	// resolved paths: macOS reports /var/... for /private/var/... temps.
+	wd, _ := os.Getwd()
+	gotDir := strings.TrimSpace(lastLine(out))
+	resolvedTmp, _ := filepath.EvalSymlinks(tmp)
+	if gotDir == tmp || gotDir == resolvedTmp {
+		t.Errorf("client cwd was honored: %q", gotDir)
+	}
+	resolvedWD, _ := filepath.EvalSymlinks(wd)
+	if gotDir != wd && gotDir != resolvedWD {
+		t.Errorf("cwd = %q, want the listener's own %q", gotDir, wd)
+	}
+}
+
+func lastLine(s string) string {
+	lines := strings.Split(strings.TrimRight(s, "\r\n"), "\n")
+	return lines[len(lines)-1]
+}
+
+// TestUnrestrictedStillHonorsClientArgv guards the default path: the
+// hardening must not change `serve shell` behavior for peers that are
+// supposed to choose their own command.
+func TestUnrestrictedStillHonorsClientArgv(t *testing.T) {
+	skipIfWindows(t)
+	h := NewShell([]string{"/bin/echo", "default"}, false)
+
+	s := newShellCapture()
+	syn, _ := json.Marshal(shellOpen{Type: "shell", Argv: []string{"/bin/echo", "client"}})
+	if err := h.OnSYN(s, syn, false); err != nil {
+		t.Fatalf("OnSYN: %v", err)
+	}
+	s.waitFinished(t)
+
+	if out := s.stdout(); !strings.Contains(out, "client") {
+		t.Errorf("client argv was ignored in unrestricted mode: %q", out)
+	}
+}
+
+// TestViewOnlyDropsInput asserts the transport-level enforcement for
+// share viewers: stdin, signals, and the FIN stdin-close side effect
+// never reach the process. (tmux attach -r is defense in depth behind
+// this, but the listener must not rely on it.)
+func TestViewOnlyDropsInput(t *testing.T) {
+	skipIfWindows(t)
+	h := NewShell(nil, false)
+	// Echoes anything it reads; stays alive until stdin closes.
+	h.ForcedArgv = []string{"/bin/sh", "-c", "while read -r line; do echo GOT:$line; done; echo EOF"}
+	h.ViewOnly = true
+
+	s := newShellCapture()
+	syn, _ := json.Marshal(shellOpen{Type: "shell"})
+	if err := h.OnSYN(s, syn, false); err != nil {
+		t.Fatalf("OnSYN: %v", err)
+	}
+
+	// Every input-shaped frame a hostile viewer could send.
+	stdin := append([]byte{shellTagStdin}, []byte("hello\n")...)
+	if err := h.OnDAT(s, stdin); err != nil {
+		t.Fatalf("OnDAT stdin: %v", err)
+	}
+	sig := append([]byte{shellTagSignal}, []byte("TERM")...)
+	if err := h.OnDAT(s, sig); err != nil {
+		t.Fatalf("OnDAT signal: %v", err)
+	}
+	if err := h.OnFIN(s, nil); err != nil {
+		t.Fatalf("OnFIN: %v", err)
+	}
+
+	time.Sleep(300 * time.Millisecond)
+	if out := s.stdout(); strings.Contains(out, "GOT:hello") || strings.Contains(out, "EOF") {
+		t.Errorf("view-only peer's input reached the process: %q", out)
+	}
+	select {
+	case <-s.finished:
+		t.Error("view-only peer's TERM signal killed the process")
+	default:
+	}
+
+	h.Close()
+	s.waitFinished(t)
+}
+
+// TestViewOnlyAllowsResize: resize only sizes the viewer's own PTY, and
+// dropping it would desync the remote grid from their viewport.
+func TestViewOnlyAllowsResize(t *testing.T) {
+	skipIfWindows(t)
+	h := NewShell(nil, false)
+	h.ForcedArgv = []string{"/bin/sh", "-c", "sleep 5"}
+	h.ViewOnly = true
+
+	s := newShellCapture()
+	syn, _ := json.Marshal(shellOpen{Type: "shell", PTY: true, Cols: 80, Rows: 24})
+	if err := h.OnSYN(s, syn, false); err != nil {
+		t.Fatalf("OnSYN: %v", err)
+	}
+
+	resize := make([]byte, 5)
+	resize[0] = shellTagResize
+	binary.LittleEndian.PutUint16(resize[1:3], 100)
+	binary.LittleEndian.PutUint16(resize[3:5], 40)
+	if err := h.OnDAT(s, resize); err != nil {
+		t.Fatalf("OnDAT resize: %v", err)
+	}
+
+	h.mu.Lock()
+	sess := h.streams[s.ID()]
+	h.mu.Unlock()
+	if sess == nil || sess.ptyFile == nil {
+		t.Fatal("no PTY session was created")
+	}
+	// pty.Getsize round-trips the ioctl we just performed.
+	cols, rows := ptySize(t, sess)
+	if cols != 100 || rows != 40 {
+		t.Errorf("PTY size = %dx%d, want 100x40 -- viewer resize was dropped", cols, rows)
+	}
+
+	h.Close()
+	s.waitFinished(t)
+}
+
+// TestControlPeerKeepsInput is the counterpart: a controller's input
+// must still flow (otherwise the share is useless).
+func TestControlPeerKeepsInput(t *testing.T) {
+	skipIfWindows(t)
+	h := NewShell(nil, false)
+	h.ForcedArgv = []string{"/bin/sh", "-c", "while read -r line; do echo GOT:$line; done"}
+
+	s := newShellCapture()
+	syn, _ := json.Marshal(shellOpen{Type: "shell"})
+	if err := h.OnSYN(s, syn, false); err != nil {
+		t.Fatalf("OnSYN: %v", err)
+	}
+	if err := h.OnDAT(s, append([]byte{shellTagStdin}, []byte("hello\n")...)); err != nil {
+		t.Fatalf("OnDAT: %v", err)
+	}
+
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if strings.Contains(s.stdout(), "GOT:hello") {
+			h.Close()
+			s.waitFinished(t)
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	h.Close()
+	t.Errorf("controller input never reached the process; output was %q", s.stdout())
+}
+
+// TestAcquireSlotGatesAdmission covers the share worker's per-role
+// limiters: one controller, N viewers, with the slot freed on exit so
+// control hands over after a disconnect.
+//
+// Each peer gets its own handler sharing one limiter, which is how the
+// worker wires it -- a handler belongs to a single connection and is
+// closed when that connection dies, so reusing one across peers would
+// not model anything that happens.
+func TestAcquireSlotGatesAdmission(t *testing.T) {
+	skipIfWindows(t)
+	var mu sync.Mutex
+	used := 0
+	acquire := func() (func(), string) {
+		mu.Lock()
+		defer mu.Unlock()
+		if used >= 1 {
+			return nil, "share already has a controller"
+		}
+		used++
+		var once sync.Once
+		return func() {
+			once.Do(func() {
+				mu.Lock()
+				used--
+				mu.Unlock()
+			})
+		}, ""
+	}
+	newPeer := func() *ShellHandler {
+		h := NewShell(nil, false)
+		h.ForcedArgv = []string{"/bin/sh", "-c", "sleep 5"}
+		h.AcquireSlot = acquire
+		return h
+	}
+	syn, _ := json.Marshal(shellOpen{Type: "shell"})
+
+	firstH := newPeer()
+	first := newShellCapture()
+	if err := firstH.OnSYN(first, syn, false); err != nil {
+		t.Fatalf("OnSYN first: %v", err)
+	}
+
+	secondH := newPeer()
+	second := newShellCapture()
+	if err := secondH.OnSYN(second, syn, false); err != nil {
+		t.Fatalf("OnSYN second: %v", err)
+	}
+	if errMsg := second.firstSYN()["error"]; !strings.Contains(errMsg, "controller") {
+		t.Errorf("second peer got error %q, want the controller-busy refusal", errMsg)
+	}
+
+	// Controller disconnects -> the slot frees and the next peer is admitted.
+	firstH.Close()
+	first.waitFinished(t)
+
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		mu.Lock()
+		free := used == 0
+		mu.Unlock()
+		if free {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("controller slot was never released after disconnect")
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	thirdH := newPeer()
+	third := newShellCapture()
+	if err := thirdH.OnSYN(third, syn, false); err != nil {
+		t.Fatalf("OnSYN third: %v", err)
+	}
+	if msg := third.firstSYN()["error"]; msg != "" {
+		t.Errorf("handover failed: third peer refused with %q", msg)
+	}
+	thirdH.Close()
+	third.waitFinished(t)
+}
+
+// TestAcquireSlotOverridesMaxConcurrent: when a caller-owned policy is
+// set it fully replaces the process-wide counter, so one share's peers
+// can't be throttled by unrelated shell activity in the same process.
+func TestAcquireSlotOverridesMaxConcurrent(t *testing.T) {
+	skipIfWindows(t)
+	h := NewShell(nil, false)
+	h.ForcedArgv = []string{"/bin/sh", "-c", "sleep 5"}
+	h.MaxConcurrent = 1
+	h.AcquireSlot = func() (func(), string) { return func() {}, "" }
+
+	var streams []*shellCapture
+	syn, _ := json.Marshal(shellOpen{Type: "shell"})
+	for i := 0; i < 3; i++ {
+		s := newShellCapture()
+		s.id = uint32(1 + 2*i)
+		if err := h.OnSYN(s, syn, false); err != nil {
+			t.Fatalf("OnSYN %d: %v", i, err)
+		}
+		if msg := s.firstSYN()["error"]; msg != "" {
+			t.Fatalf("peer %d refused (%q) despite the custom policy admitting it", i, msg)
+		}
+		streams = append(streams, s)
+	}
+	h.Close()
+	for _, s := range streams {
+		s.waitFinished(t)
+	}
+}
+
+func TestDuplicateStreamCannotReplaceRunningShell(t *testing.T) {
+	skipIfWindows(t)
+	h := NewShell(nil, false)
+	h.ForcedArgv = []string{"/bin/sh", "-c", "sleep 5"}
+	syn, _ := json.Marshal(shellOpen{Type: "shell"})
+
+	first := newShellCapture()
+	if err := h.OnSYN(first, syn, false); err != nil {
+		t.Fatal(err)
+	}
+	duplicate := newShellCapture() // same stream ID as first
+	if err := h.OnSYN(duplicate, syn, false); err != nil {
+		t.Fatal(err)
+	}
+	if msg := duplicate.firstSYN()["error"]; !strings.Contains(msg, "already open") {
+		t.Fatalf("duplicate stream error = %q", msg)
+	}
+
+	h.Close()
+	first.waitFinished(t)
+}
+
+// ptySize reads back the PTY's window size via the same ioctl path the
+// resize handler uses.
+func ptySize(t *testing.T, sess *shellSession) (cols, rows int) {
+	t.Helper()
+	terminal, ok := sess.ptyFile.(ptylib.UnixPty)
+	if !ok {
+		t.Fatalf("PTY has type %T, want pty.UnixPty", sess.ptyFile)
+	}
+	ws, err := pty.GetsizeFull(terminal.Master())
+	if err != nil {
+		t.Fatalf("GetsizeFull: %v", err)
+	}
+	return int(ws.Cols), int(ws.Rows)
+}
+
+func TestClosedHandlerDoesNotExecuteCommand(t *testing.T) {
+	skipIfWindows(t)
+	marker := filepath.Join(t.TempDir(), "started")
+	h := NewShell(nil, false)
+	h.ForcedArgv = []string{"/bin/sh", "-c", "touch \"$0\"", marker}
+
+	h.Close()
+
+	s := newShellCapture()
+	syn, _ := json.Marshal(shellOpen{Type: "shell", PTY: true})
+	if err := h.OnSYN(s, syn, false); err != nil {
+		t.Fatalf("OnSYN: %v", err)
+	}
+
+	h.mu.Lock()
+	tracked := len(h.streams)
+	h.mu.Unlock()
+	if tracked != 0 {
+		t.Errorf("handler tracked %d process(es) after being closed", tracked)
+	}
+
+	if _, err := os.Stat(marker); !os.IsNotExist(err) {
+		t.Fatalf("closed handler executed its command; marker stat error = %v", err)
+	}
+}

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -17,7 +17,10 @@ export BITBANG_TEST_SERVER="${BITBANG_TEST_SERVER:-test.bitba.ng}"
 case "${1:-all}" in
     unit)
         echo "Running unit tests..."
-        go test ./internal/... -v
+        # ./... rather than ./internal/...; the latter silently skips
+        # every test under cmd/bitbang (arg reordering, serve-mode
+        # routing, the device table, share state), which is what CI runs.
+        go test ./... -v
         ;;
     e2e)
         echo "Running E2E tests..."
@@ -30,7 +33,10 @@ case "${1:-all}" in
         ;;
     all)
         echo "Running unit tests..."
-        go test ./internal/... -v
+        # ./... rather than ./internal/...; the latter silently skips
+        # every test under cmd/bitbang (arg reordering, serve-mode
+        # routing, the device table, share state), which is what CI runs.
+        go test ./... -v
         echo ""
         echo "Running E2E tests..."
         mkdir -p tests/e2e/screenshots


### PR DESCRIPTION
# share: publish a running tmux session as a URL

Closes #5.

## Summary

`bitbang share` publishes a tmux session that is already in progress. It
returns a control URL and a separate view-only URL, or only the view URL when
started with `--read-only`.

```text
bitbang share
bitbang share --read-only
bitbang share status
bitbang share rotate
bitbang share stop
```

The command returns after publication, so suspending a task, sharing it, and
resuming it works without changing how the task was started.

## Design

- Each peer gets its own stock `tmux attach-session` process. Control peers
  attach read-write; viewers attach with `-r`.
- The shell handler pins argv, environment, and cwd for these processes. It
  also drops viewer stdin, signals, and EOF before tmux sees them.
- One ephemeral identity carries two independent access codes. Authorization
  maps each code to a control or view role without signaling-server changes.
- The control role has one slot. The view role has `--max-viewers` slots.
  Reservations begin at authorization and last for the connection lifetime,
  including peers that never open a terminal.
- A detached `_bbshare_*` tmux session supervises the worker. There is no
  daemonization or PID file.
- Shares end on `--ttl`, `share stop`, source-session removal, or signaling
  preemption. The source session is never stopped by share cleanup.

Share URLs carry `!ephemeral` in the fragment. Browser parsing already ignores
unknown fragment flags, and CLI clients use the flag to avoid saving an expired
share credential to `devices.json`.

## Lifecycle safety

The command changes no tmux options. It reads the effective `window-size` and
warns when it is not `latest`, but preserves the user's configuration.

State contains bearer credentials and is written with mode 0600 inside a 0700
directory. A per-target advisory lock spans classification, cleanup, worker
creation, and state acceptance. Cleanup only acts after a successful
server-wide tmux listing proves the management pane is gone, or after the
socket proves that no server remains. Failed or ambiguous probes preserve
state.

Connection teardown now also covers peers whose data channel never opens, and
both normal listeners and share workers bound incomplete handshakes. This
prevents abandoned WebRTC requests from permanently consuming admission
slots.

## Platform behavior

Hosting requires tmux 3.2 or newer on Unix or WSL. Native Windows clients can
open control and view URLs; attempting to host reports the platform limitation
before looking for tmux. The changes preserve the current ConPTY shell path and
compile as Windows test binaries.

## Verification

- `go build ./...`
- `go vet ./...`
- `go test -count=1 ./...`
- `go test -race -count=1 ./...`
- full suite with `TERM=dumb`
- full suite with tmux absent from `PATH`
- Windows cross-compiled test binaries
- every commit independently built, vetted, tested, and cross-compiled
- real tmux 3.6a integration tests for output capture, read-only attachment,
  resize isolation, source loss, exact targeting, lifecycle locks, retained
  dead panes, and stale-state cleanup
- live `bitba.ng` smoke test: existing output rendered, view input was blocked,
  control input executed, share URLs were not persisted, status recovered the
  same URLs, and stop left the source session running

Linux CI now installs tmux, so the tmux integration tests execute in pull
requests instead of silently skipping.

## Review order

1. `peer: add role-aware terminal access`
2. `share: add the tmux publication worker`
3. `share: add tmux session lifecycle commands`
4. `docs: document tmux session sharing`
