### PR TITLE
Add negotiated per-stream flow control

### DIFF
--- a/cmd/bitbang/serve.go
+++ b/cmd/bitbang/serve.go
@@ -553,7 +553,7 @@ func startListener(cfg serveConfig) {
 
 			// Per-connection teardown, run when the data channel closes.
 			var onClose []func()
-			onClose = append(onClose, release)
+			onClose = append(onClose, sess.Close, release)
 			// Kill any shell processes — without this they outlive the
 			// browser tab and keep holding their max-sessions slot.
 			if shellHandler != nil {

--- a/internal/client/e2e_harness_test.go
+++ b/internal/client/e2e_harness_test.go
@@ -252,9 +252,10 @@ func startListener(host string, id *identity.Identity, handlers ...streamtype.St
 				log.Printf("[e2e listener] HandleRequest: %v", err)
 				return
 			}
+			newSession := session.New(c.DC, auth.New(""), false, handlers...)
 			mu.Lock()
 			conn = c
-			sess = session.New(c.DC, auth.New(""), false, handlers...)
+			sess = newSession
 			mu.Unlock()
 			var closeHandlers []func()
 			for _, handler := range handlers {
@@ -262,11 +263,10 @@ func startListener(host string, id *identity.Identity, handlers ...streamtype.St
 					closeHandlers = append(closeHandlers, closer.CloseAll)
 				}
 			}
-			if len(closeHandlers) > 0 {
-				c.OnClose = func() {
-					for _, closeHandler := range closeHandlers {
-						closeHandler()
-					}
+			c.OnClose = func() {
+				newSession.Close()
+				for _, closeHandler := range closeHandlers {
+					closeHandler()
 				}
 			}
 		case "answer":

--- a/internal/client/session.go
+++ b/internal/client/session.go
@@ -18,6 +18,13 @@ import (
 // from this package routes here instead.
 var stderr = os.Stderr
 
+var (
+	errStreamQueueFull       = errors.New("stream receive queue full")
+	errReceiveWindowExceeded = errors.New("stream receive window exceeded")
+	errStreamClosed          = errors.New("stream closed")
+	errStreamFinished        = errors.New("stream direction already finished")
+)
+
 // Session wraps the data channel after bidirectional verify has succeeded
 // and the control-stream `ready` message has been received. From here on
 // the caller drives SWSP file (or future shell/tcp/etc.) streams.
@@ -33,8 +40,9 @@ type Session struct {
 	// ServerCaps and ServerVersion come from the listener's `ready` and
 	// let callers gate behavior (e.g. don't try `file` ops if the server
 	// doesn't advertise it).
-	ServerCaps    []string
-	ServerVersion int
+	ServerCaps        []string
+	ServerVersion     int
+	NegotiatedVersion int
 
 	nextStreamID uint32
 	mu           sync.Mutex
@@ -42,17 +50,41 @@ type Session struct {
 	closed       atomic.Bool
 	done         chan struct{}
 	closeOnce    sync.Once
+
+	// sendFrameOverride lets unit tests capture wire output without creating a
+	// real WebRTC data channel. Production sessions leave it nil.
+	sendFrameOverride func(streamID uint32, flags uint16, payload []byte) error
 }
 
-// stream is the per-stream state held by the session: an inbound frame
-// queue the caller drains via the public Inbox method. SYN/DAT/FIN
-// frames all arrive on the same channel — the caller inspects flags.
+// stream is the per-stream state held by the session. The dispatcher writes
+// into pending without waiting for the caller; a dedicated worker preserves
+// frame order while handing frames to the public inbox.
 type stream struct {
 	id        uint32
 	inbox     chan protocol.Frame
+	pending   chan protocol.Frame
 	abandoned chan struct{}
 	abandon   sync.Once
 	closeOnce sync.Once
+
+	queueMu           sync.Mutex
+	queuedBytes       int
+	queuedFrames      int
+	receivedBytes     uint64
+	consumedBytes     uint64
+	advertisedMax     uint64
+	lastUpdateAt      uint64
+	initialWindowSent bool
+
+	sendMu           sync.Mutex
+	writeMu          sync.Mutex
+	sentBytes        uint64
+	sendLimit        uint64
+	sendWake         chan struct{}
+	streamErr        error
+	inboundFIN       atomic.Bool
+	inboundDelivered atomic.Bool
+	outboundFIN      atomic.Bool
 }
 
 // newSession constructs a Session bound to a data channel. The peer is
@@ -141,25 +173,24 @@ func (s *Session) handshake(p *Peer, path string, caps []string, pinPrompt func(
 			continue
 		}
 		var ctl struct {
-			Type          string   `json:"type"`
-			Message       string   `json:"message"`
-			Success       bool     `json:"success"`
-			Caps          []string `json:"caps"`
-			ServerVersion int      `json:"server_version"`
+			Type              string   `json:"type"`
+			Message           string   `json:"message"`
+			Success           bool     `json:"success"`
+			Caps              []string `json:"caps"`
+			ServerVersion     int      `json:"server_version"`
+			NegotiatedVersion int      `json:"negotiated_version"`
 		}
 		_ = json.Unmarshal(f.Payload, &ctl)
 
 		switch ctl.Type {
 		case "ready":
 			s.ServerCaps = ctl.Caps
-			s.ServerVersion = ctl.ServerVersion
-			if s.ServerVersion == 0 {
-				// v2 listeners send {type:"ready"} with no version.
-				s.ServerVersion = 2
+			if err := s.setNegotiatedVersion(ctl.ServerVersion, ctl.NegotiatedVersion); err != nil {
+				return err
 			}
 			if s.Verbose {
-				fmt.Fprintf(stderr, "[client] device ready (server v%d, caps: %v)\n",
-					s.ServerVersion, s.ServerCaps)
+				fmt.Fprintf(stderr, "[client] device ready (server v%d, negotiated v%d, caps: %v)\n",
+					s.ServerVersion, s.NegotiatedVersion, s.ServerCaps)
 			}
 			return nil
 		case "auth_required":
@@ -203,9 +234,30 @@ func (s *Session) handshake(p *Peer, path string, caps []string, pinPrompt func(
 	}
 }
 
-// startDispatcher takes over the DC message queue from the session layer
-// and routes inbound frames to their owning stream's inbox. Run as a
-// goroutine after handshake completes; exits when the DC closes.
+func (s *Session) setNegotiatedVersion(serverVersion, negotiatedVersion int) error {
+	if serverVersion == 0 {
+		// v2 listeners send {type:"ready"} with no version.
+		serverVersion = 2
+	}
+	maxVersion := protocol.NegotiateSWSPVersion(serverVersion)
+	if maxVersion < 2 {
+		return fmt.Errorf("listener returned unsupported server version %d", serverVersion)
+	}
+	if negotiatedVersion == 0 {
+		negotiatedVersion = maxVersion
+	} else if negotiatedVersion < 2 || negotiatedVersion > maxVersion {
+		return fmt.Errorf("listener returned invalid negotiated version %d", negotiatedVersion)
+	}
+	s.ServerVersion = serverVersion
+	s.NegotiatedVersion = negotiatedVersion
+	return nil
+}
+
+// startDispatcher takes over the DC message queue from the session layer and
+// routes inbound frames to bounded per-stream queues. It never waits for an
+// individual stream consumer, so one stalled stream cannot delay the rest of
+// the session. Run as a goroutine after handshake completes; exits when the DC
+// closes.
 func (s *Session) startDispatcher(p *Peer) {
 	go func() {
 		defer s.finishStreams()
@@ -227,8 +279,11 @@ func (s *Session) startDispatcher(p *Peer) {
 				continue
 			}
 			if frame.StreamID == 0 {
-				// Late stream-0 messages (e.g. a server-initiated error)
-				// are uncommon for v3; log + drop.
+				if s.flowControlEnabled() && s.handleControl(frame) {
+					continue
+				}
+				// Other late stream-0 messages are informational in the
+				// established session and can be ignored.
 				if s.Verbose {
 					fmt.Fprintf(stderr, "[client] ignoring late stream-0 frame flags=%#x\n", frame.Flags)
 				}
@@ -243,23 +298,21 @@ func (s *Session) startDispatcher(p *Peer) {
 				}
 				continue
 			}
-			// Delivery is lossless until the consumer explicitly abandons
-			// the stream or the session closes. The selects make a blocked
-			// delivery teardown-safe without racing a send against close.
-			select {
-			case st.inbox <- frame:
-			case <-st.abandoned:
+			if err := st.enqueue(frame, s.flowControlEnabled()); err != nil {
+				// The stream has exceeded its private queue or was abandoned.
+				// Detach only this stream; the dispatcher must remain available
+				// to every other stream sharing the session.
+				if !errors.Is(err, errStreamClosed) {
+					code := "receive_overflow"
+					switch {
+					case errors.Is(err, errReceiveWindowExceeded):
+						code = "flow_control_violation"
+					case errors.Is(err, errStreamFinished):
+						code = "protocol_error"
+					}
+					s.failStream(st, code, err.Error(), true)
+				}
 				continue
-			case <-p.DCClosed():
-				s.markClosed()
-				return
-			case <-s.done:
-				return
-			}
-			if frame.IsFIN() {
-				// FIN closes the stream's inbox so callers ranging over
-				// it see the channel close instead of blocking forever.
-				s.finishStream(st.id, st)
 			}
 		}
 	}()
@@ -276,37 +329,229 @@ func (s *Session) OpenStream() *Stream {
 	s.nextStreamID += 2
 	st := &stream{
 		id:        id,
-		inbox:     make(chan protocol.Frame, 256),
+		inbox:     make(chan protocol.Frame),
+		pending:   make(chan protocol.Frame, protocol.MaxQueuedStreamFrames),
 		abandoned: make(chan struct{}),
+		sendWake:  make(chan struct{}),
+	}
+	if s.closed.Load() {
+		s.mu.Unlock()
+		st.fail(errors.New("data channel closed"))
+		st.closeOnce.Do(func() { close(st.inbox) })
+		return &Stream{s: s, st: st}
 	}
 	s.streams[id] = st
 	s.mu.Unlock()
+	go s.deliverStream(st)
 	return &Stream{s: s, st: st}
 }
 
-func (s *Session) closeStream(id uint32) {
+func (s *Session) detachStream(id uint32, st *stream) bool {
 	s.mu.Lock()
-	st := s.streams[id]
-	if st != nil {
+	removed := false
+	if s.streams[id] == st {
 		delete(s.streams, id)
+		removed = true
 	}
 	s.mu.Unlock()
-	if st != nil {
-		st.abandon.Do(func() { close(st.abandoned) })
+	return removed
+}
+
+func (s *Session) detachFinishedStream(st *stream) {
+	if st.inboundDelivered.Load() && st.outboundFIN.Load() {
+		s.detachStream(st.id, st)
 	}
 }
 
-// finishStream is called only by the dispatcher, the sole inbox sender.
-func (s *Session) finishStream(id uint32, st *stream) {
+func (s *Session) findStream(id uint32) *stream {
 	s.mu.Lock()
-	if s.streams[id] == st {
-		delete(s.streams, id)
-	}
+	st := s.streams[id]
 	s.mu.Unlock()
-	st.closeOnce.Do(func() { close(st.inbox) })
+	return st
+}
+
+func (s *Session) failStream(st *stream, code, message string, notifyPeer bool) {
+	if !s.detachStream(st.id, st) {
+		return
+	}
+	st.fail(errors.New(message))
+	if notifyPeer {
+		go func() {
+			// Preserve terminal ordering on the reliable data channel: any
+			// frame that already reserved credit completes before the reset,
+			// while blocked/future writers observe st.fail and stop.
+			st.writeMu.Lock()
+			defer st.writeMu.Unlock()
+			if s.flowControlEnabled() {
+				_ = s.sendStreamReset(st.id, code, message)
+				return
+			}
+			_ = s.sendRawFrame(st.id, protocol.FlagFIN, nil)
+		}()
+	}
+}
+
+func (s *Session) deliverStream(st *stream) {
+	defer st.closeOnce.Do(func() { close(st.inbox) })
+	for {
+		select {
+		case frame := <-st.pending:
+			select {
+			case st.inbox <- frame:
+				maxBytes, update := st.consume(frame, s.flowControlEnabled())
+				if update && !frame.IsFIN() {
+					if err := s.sendWindowUpdate(st.id, maxBytes); err != nil {
+						s.failStream(st, "control_send_failed", err.Error(), false)
+						return
+					}
+				}
+				if frame.IsFIN() {
+					// Keep the state session-owned until FIN reaches the caller.
+					// Otherwise an abandoned inbox can strand this worker after
+					// both wire directions have already finished.
+					st.inboundDelivered.Store(true)
+					s.detachFinishedStream(st)
+					return
+				}
+			case <-st.abandoned:
+				st.release(frame)
+				return
+			case <-s.done:
+				st.release(frame)
+				return
+			}
+		case <-st.abandoned:
+			return
+		case <-s.done:
+			return
+		}
+	}
+}
+
+func (st *stream) enqueue(frame protocol.Frame, enforceWindow bool) error {
+	if st.inboundFIN.Load() {
+		return errStreamFinished
+	}
+	flowBytes := frame.FlowBytes()
+	st.queueMu.Lock()
+	if enforceWindow && (st.receivedBytes > st.advertisedMax || flowBytes > st.advertisedMax-st.receivedBytes) {
+		st.queueMu.Unlock()
+		return errReceiveWindowExceeded
+	}
+	if st.queuedFrames >= protocol.MaxQueuedStreamFrames || st.queuedBytes+len(frame.Payload) > protocol.InitialStreamWindow {
+		st.queueMu.Unlock()
+		return errStreamQueueFull
+	}
+	st.queuedFrames++
+	st.queuedBytes += len(frame.Payload)
+	st.receivedBytes += flowBytes
+	if frame.IsFIN() {
+		st.inboundFIN.Store(true)
+	}
+	st.queueMu.Unlock()
+
+	select {
+	case st.pending <- frame:
+		return nil
+	case <-st.abandoned:
+		st.release(frame)
+		return errStreamClosed
+	default:
+		// queuedFrames includes the frame a worker may currently be handing
+		// to the caller, so this should only be reachable during teardown.
+		st.release(frame)
+		return errStreamQueueFull
+	}
+}
+
+func (st *stream) release(frame protocol.Frame) {
+	st.queueMu.Lock()
+	st.queuedFrames--
+	st.queuedBytes -= len(frame.Payload)
+	st.queueMu.Unlock()
+}
+
+func (st *stream) consume(frame protocol.Frame, flowControl bool) (uint64, bool) {
+	flowBytes := frame.FlowBytes()
+	st.queueMu.Lock()
+	st.queuedFrames--
+	st.queuedBytes -= len(frame.Payload)
+	if !flowControl || flowBytes == 0 {
+		st.queueMu.Unlock()
+		return 0, false
+	}
+	st.consumedBytes += flowBytes
+	if st.consumedBytes-st.lastUpdateAt < protocol.StreamWindowUpdateThreshold {
+		st.queueMu.Unlock()
+		return 0, false
+	}
+	st.lastUpdateAt = st.consumedBytes
+	st.advertisedMax = protocol.InitialStreamWindow + st.consumedBytes
+	maxBytes := st.advertisedMax
+	st.queueMu.Unlock()
+	return maxBytes, true
+}
+
+func (st *stream) prepareInitialWindow() (uint64, bool) {
+	st.queueMu.Lock()
+	defer st.queueMu.Unlock()
+	if st.initialWindowSent {
+		return st.advertisedMax, false
+	}
+	st.initialWindowSent = true
+	st.advertisedMax = protocol.InitialStreamWindow
+	return st.advertisedMax, true
+}
+
+func (st *stream) reserveSend(n uint64, sessionDone <-chan struct{}) error {
+	for {
+		st.sendMu.Lock()
+		if st.streamErr != nil {
+			err := st.streamErr
+			st.sendMu.Unlock()
+			return err
+		}
+		if n <= st.sendLimit-st.sentBytes {
+			st.sentBytes += n
+			st.sendMu.Unlock()
+			return nil
+		}
+		wake := st.sendWake
+		st.sendMu.Unlock()
+
+		select {
+		case <-wake:
+		case <-st.abandoned:
+			return errStreamClosed
+		case <-sessionDone:
+			return errors.New("data channel closed")
+		}
+	}
+}
+
+func (st *stream) updateSendLimit(maxBytes uint64) {
+	st.sendMu.Lock()
+	if maxBytes > st.sendLimit {
+		st.sendLimit = maxBytes
+		close(st.sendWake)
+		st.sendWake = make(chan struct{})
+	}
+	st.sendMu.Unlock()
+}
+
+func (st *stream) fail(err error) {
+	st.sendMu.Lock()
+	if st.streamErr == nil {
+		st.streamErr = err
+		close(st.sendWake)
+		st.sendWake = make(chan struct{})
+	}
+	st.sendMu.Unlock()
+	st.abandon.Do(func() { close(st.abandoned) })
 }
 
 func (s *Session) finishStreams() {
+	s.markClosed()
 	s.mu.Lock()
 	streams := make([]*stream, 0, len(s.streams))
 	for id, st := range s.streams {
@@ -315,9 +560,8 @@ func (s *Session) finishStreams() {
 	}
 	s.mu.Unlock()
 	for _, st := range streams {
-		st.closeOnce.Do(func() { close(st.inbox) })
+		st.abandon.Do(func() { close(st.abandoned) })
 	}
-	s.markClosed()
 }
 
 func (s *Session) markClosed() {
@@ -327,15 +571,164 @@ func (s *Session) markClosed() {
 	})
 }
 
+func (s *Session) flowControlEnabled() bool {
+	return s.NegotiatedVersion >= 4
+}
+
+func (s *Session) handleControl(frame protocol.Frame) bool {
+	if !frame.IsSYN() {
+		return false
+	}
+	var header struct {
+		Type string `json:"type"`
+	}
+	if err := json.Unmarshal(frame.Payload, &header); err != nil {
+		return false
+	}
+
+	switch header.Type {
+	case protocol.ControlWindowUpdate:
+		var update protocol.WindowUpdate
+		if err := json.Unmarshal(frame.Payload, &update); err != nil {
+			s.resetMalformedControl(frame.Payload, err)
+			return true
+		}
+		st := s.findStream(update.StreamID)
+		if st == nil {
+			return true
+		}
+		if update.StreamID == 0 || update.MaxBytes == 0 {
+			s.failStream(st, "invalid_control", "invalid stream window update", true)
+			return true
+		}
+		st.updateSendLimit(update.MaxBytes)
+		return true
+
+	case protocol.ControlStreamReset:
+		var reset protocol.StreamReset
+		if err := json.Unmarshal(frame.Payload, &reset); err != nil {
+			s.resetMalformedControl(frame.Payload, err)
+			return true
+		}
+		st := s.findStream(reset.StreamID)
+		if st == nil {
+			return true
+		}
+		message := reset.Message
+		if message == "" {
+			message = reset.Code
+		}
+		if message == "" {
+			message = "stream reset by peer"
+		}
+		s.failStream(st, reset.Code, message, false)
+		return true
+	}
+
+	return false
+}
+
+func (s *Session) resetMalformedControl(payload []byte, controlErr error) {
+	var target struct {
+		StreamID uint32 `json:"stream_id"`
+	}
+	if json.Unmarshal(payload, &target) != nil || target.StreamID == 0 {
+		return
+	}
+	if st := s.findStream(target.StreamID); st != nil {
+		s.failStream(st, "invalid_control", controlErr.Error(), true)
+	}
+}
+
+func (s *Session) sendWindowUpdate(streamID uint32, maxBytes uint64) error {
+	payload, err := json.Marshal(protocol.WindowUpdate{
+		Type:     protocol.ControlWindowUpdate,
+		StreamID: streamID,
+		MaxBytes: maxBytes,
+	})
+	if err != nil {
+		return err
+	}
+	return s.sendControlSYN(payload)
+}
+
+func (s *Session) sendStreamReset(streamID uint32, code, message string) error {
+	payload, err := json.Marshal(protocol.StreamReset{
+		Type:     protocol.ControlStreamReset,
+		StreamID: streamID,
+		Code:     code,
+		Message:  message,
+	})
+	if err != nil {
+		return err
+	}
+	return s.sendControlSYN(payload)
+}
+
 func (s *Session) sendFrame(streamID uint32, flags uint16, payload []byte) error {
-	if s.closed.Load() || s.DC.ReadyState() != webrtc.DataChannelStateOpen {
+	if err := protocol.ValidateFramePayload(payload); err != nil {
+		return err
+	}
+	frame := protocol.Frame{StreamID: streamID, Flags: flags, Payload: payload}
+	var st *stream
+	var sendInitialWindow bool
+	var initialWindow uint64
+	if streamID != 0 {
+		st = s.findStream(streamID)
+		if st == nil {
+			return errStreamClosed
+		}
+	}
+	if st != nil {
+		st.writeMu.Lock()
+		defer st.writeMu.Unlock()
+		if st.outboundFIN.Load() {
+			return errStreamFinished
+		}
+	}
+	if s.flowControlEnabled() && streamID != 0 {
+		if frame.IsSYN() {
+			initialWindow, sendInitialWindow = st.prepareInitialWindow()
+		}
+		if err := st.reserveSend(frame.FlowBytes(), s.done); err != nil {
+			return err
+		}
+	}
+
+	if err := s.sendRawFrame(streamID, flags, payload); err != nil {
+		return err
+	}
+	if sendInitialWindow {
+		if err := s.sendWindowUpdate(streamID, initialWindow); err != nil {
+			s.failStream(st, "control_send_failed", err.Error(), false)
+			return err
+		}
+	}
+	if st != nil && frame.IsFIN() {
+		st.outboundFIN.Store(true)
+		s.detachFinishedStream(st)
+	}
+	return nil
+}
+
+func (s *Session) sendRawFrame(streamID uint32, flags uint16, payload []byte) error {
+	if err := protocol.ValidateFramePayload(payload); err != nil {
+		return err
+	}
+	if s.closed.Load() {
+		return errors.New("data channel closed")
+	}
+	if s.sendFrameOverride != nil {
+		return s.sendFrameOverride(streamID, flags, payload)
+	}
+	if s.DC == nil || s.DC.ReadyState() != webrtc.DataChannelStateOpen {
 		return errors.New("data channel closed")
 	}
 	return s.DC.Send(protocol.BuildFrame(streamID, flags, payload))
 }
 
 func (s *Session) sendControlSYN(payload []byte) error {
-	return s.sendFrame(0, protocol.FlagSYN, payload)
+	return s.sendRawFrame(0, protocol.FlagSYN, payload)
 }
 
 // Close closes the data channel and returns. Anything left in flight
@@ -343,7 +736,7 @@ func (s *Session) sendControlSYN(payload []byte) error {
 // to the OS to reap when the process exits — pion's synchronous
 // PC.Close() path is slow on relay sessions and isn't worth waiting for.
 func (s *Session) Close() {
-	s.markClosed()
+	s.finishStreams()
 	if s.DC != nil {
 		_ = s.DC.Close()
 	}
@@ -387,4 +780,16 @@ func (s *Stream) BufferedAmount() uint64 { return s.s.DC.BufferedAmount() }
 // Close drops the stream from the session's routing table. The caller
 // is expected to have sent FIN already; this is just cleanup if the
 // stream is being abandoned (e.g. on error).
-func (s *Stream) Close() { s.s.closeStream(s.st.id) }
+func (s *Stream) Close() {
+	// A v4 reset is full-duplex, so it also cancels a response that is still
+	// arriving after our FIN (for example, a download whose local writer
+	// failed). Legacy peers only understand directional FIN; avoid sending it
+	// twice when our outbound direction already ended.
+	if s.s.flowControlEnabled() || !s.st.outboundFIN.Load() {
+		s.s.failStream(s.st, "cancelled", "stream closed", true)
+		return
+	}
+	if s.s.detachStream(s.st.id, s.st) {
+		s.st.fail(errStreamClosed)
+	}
+}

--- a/internal/client/session.go
+++ b/internal/client/session.go
@@ -23,6 +23,7 @@ var (
 	errReceiveWindowExceeded = errors.New("stream receive window exceeded")
 	errStreamClosed          = errors.New("stream closed")
 	errStreamFinished        = errors.New("stream direction already finished")
+	errStreamNotStarted      = errors.New("stream has not sent SYN")
 )
 
 // Session wraps the data channel after bidirectional verify has succeeded
@@ -67,14 +68,14 @@ type stream struct {
 	abandon   sync.Once
 	closeOnce sync.Once
 
-	queueMu           sync.Mutex
-	queuedBytes       int
-	queuedFrames      int
-	receivedBytes     uint64
-	consumedBytes     uint64
-	advertisedMax     uint64
-	lastUpdateAt      uint64
-	initialWindowSent bool
+	queueMu       sync.Mutex
+	queuedBytes   int
+	queuedFrames  int
+	receivedBytes uint64
+	consumedBytes uint64
+	advertisedMax uint64
+	lastUpdateAt  uint64
+	windowActive  bool
 
 	sendMu           sync.Mutex
 	writeMu          sync.Mutex
@@ -307,7 +308,7 @@ func (s *Session) startDispatcher(p *Peer) {
 					switch {
 					case errors.Is(err, errReceiveWindowExceeded):
 						code = "flow_control_violation"
-					case errors.Is(err, errStreamFinished):
+					case errors.Is(err, errStreamFinished), errors.Is(err, errStreamNotStarted):
 						code = "protocol_error"
 					}
 					s.failStream(st, code, err.Error(), true)
@@ -434,6 +435,10 @@ func (st *stream) enqueue(frame protocol.Frame, enforceWindow bool) error {
 	}
 	flowBytes := frame.FlowBytes()
 	st.queueMu.Lock()
+	if enforceWindow && !st.windowActive {
+		st.queueMu.Unlock()
+		return errStreamNotStarted
+	}
 	if enforceWindow && (st.receivedBytes > st.advertisedMax || flowBytes > st.advertisedMax-st.receivedBytes) {
 		st.queueMu.Unlock()
 		return errReceiveWindowExceeded
@@ -492,15 +497,23 @@ func (st *stream) consume(frame protocol.Frame, flowControl bool) (uint64, bool)
 	return maxBytes, true
 }
 
-func (st *stream) prepareInitialWindow() (uint64, bool) {
+func (st *stream) activateInitialWindow() {
+	st.queueMu.Lock()
+	activate := !st.windowActive
+	if activate {
+		st.advertisedMax = protocol.InitialStreamWindow
+		st.windowActive = true
+	}
+	st.queueMu.Unlock()
+	if activate {
+		st.updateSendLimit(protocol.InitialStreamWindow)
+	}
+}
+
+func (st *stream) initialWindowActive() bool {
 	st.queueMu.Lock()
 	defer st.queueMu.Unlock()
-	if st.initialWindowSent {
-		return st.advertisedMax, false
-	}
-	st.initialWindowSent = true
-	st.advertisedMax = protocol.InitialStreamWindow
-	return st.advertisedMax, true
+	return st.windowActive
 }
 
 func (st *stream) reserveSend(n uint64, sessionDone <-chan struct{}) error {
@@ -671,8 +684,6 @@ func (s *Session) sendFrame(streamID uint32, flags uint16, payload []byte) error
 	}
 	frame := protocol.Frame{StreamID: streamID, Flags: flags, Payload: payload}
 	var st *stream
-	var sendInitialWindow bool
-	var initialWindow uint64
 	if streamID != 0 {
 		st = s.findStream(streamID)
 		if st == nil {
@@ -686,9 +697,16 @@ func (s *Session) sendFrame(streamID uint32, flags uint16, payload []byte) error
 			return errStreamFinished
 		}
 	}
-	if s.flowControlEnabled() && streamID != 0 {
+	flowControl := s.flowControlEnabled() && streamID != 0
+	if flowControl {
+		if !frame.IsSYN() && !st.initialWindowActive() {
+			return errStreamNotStarted
+		}
 		if frame.IsSYN() {
-			initialWindow, sendInitialWindow = st.prepareInitialWindow()
+			// Activate receive credit before the ordered SYN goes on the wire,
+			// so an immediate response cannot race the receive-window check.
+			// writeMu keeps later local data behind the SYN itself.
+			st.activateInitialWindow()
 		}
 		if err := st.reserveSend(frame.FlowBytes(), s.done); err != nil {
 			return err
@@ -696,13 +714,10 @@ func (s *Session) sendFrame(streamID uint32, flags uint16, payload []byte) error
 	}
 
 	if err := s.sendRawFrame(streamID, flags, payload); err != nil {
-		return err
-	}
-	if sendInitialWindow {
-		if err := s.sendWindowUpdate(streamID, initialWindow); err != nil {
-			s.failStream(st, "control_send_failed", err.Error(), false)
-			return err
+		if flowControl && frame.IsSYN() {
+			s.failStream(st, "send_error", err.Error(), false)
 		}
+		return err
 	}
 	if st != nil && frame.IsFIN() {
 		st.outboundFIN.Store(true)

--- a/internal/client/session_test.go
+++ b/internal/client/session_test.go
@@ -1,37 +1,565 @@
 package client
 
 import (
+	"encoding/json"
+	"errors"
 	"testing"
 	"time"
 
 	"github.com/richlegrand/bitbang/internal/protocol"
 )
 
-func TestSessionDoneClosesWhenDispatcherInboxIsFull(t *testing.T) {
-	p := &Peer{
-		dcMsg:    make(chan []byte, 257),
-		dcClosed: make(chan struct{}),
+func TestSessionNegotiatesFlowControlVersion(t *testing.T) {
+	tests := []struct {
+		name       string
+		server     int
+		negotiated int
+		wantServer int
+		want       int
+		wantErr    bool
+	}{
+		{name: "legacy missing version", wantServer: 2, want: 2},
+		{name: "v3 fallback", server: 3, wantServer: 3, want: 3},
+		{name: "v4 explicit", server: 4, negotiated: 4, wantServer: 4, want: 4},
+		{name: "future server clamps locally", server: 99, negotiated: 4, wantServer: 99, want: 4},
+		{name: "lower negotiated version", server: 4, negotiated: 3, wantServer: 4, want: 3},
+		{name: "negotiated above server", server: 3, negotiated: 4, wantErr: true},
+		{name: "unsupported server", server: 1, wantErr: true},
 	}
-	sess := newSession(p)
-	t.Cleanup(sess.Close)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sess := &Session{}
+			err := sess.setNegotiatedVersion(tt.server, tt.negotiated)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("setNegotiatedVersion returned nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("setNegotiatedVersion: %v", err)
+			}
+			if sess.ServerVersion != tt.wantServer || sess.NegotiatedVersion != tt.want {
+				t.Fatalf("versions = server %d negotiated %d, want server %d negotiated %d",
+					sess.ServerVersion, sess.NegotiatedVersion, tt.wantServer, tt.want)
+			}
+		})
+	}
+}
+
+func TestSessionV3DataPathDoesNotUseCredit(t *testing.T) {
+	p, sess := newDispatchTestSession(t, 2)
+	sess.NegotiatedVersion = 3
+	sent := make(chan protocol.Frame, 3)
+	sess.sendFrameOverride = func(streamID uint32, flags uint16, payload []byte) error {
+		sent <- protocol.Frame{StreamID: streamID, Flags: flags, Payload: append([]byte(nil), payload...)}
+		return nil
+	}
+	stream := sess.OpenStream()
+	sess.startDispatcher(p)
+	if err := stream.WriteSYN([]byte(`{"type":"test"}`)); err != nil {
+		t.Fatalf("v3 WriteSYN: %v", err)
+	}
+	if err := stream.WriteDAT([]byte("request")); err != nil {
+		t.Fatalf("v3 WriteDAT: %v", err)
+	}
+	for i := 0; i < 2; i++ {
+		frame := <-sent
+		if frame.StreamID != stream.ID() {
+			t.Fatalf("v3 sent control frame: %#v", frame)
+		}
+	}
+
+	p.dcMsg <- protocol.BuildFrame(stream.ID(), protocol.FlagDAT, []byte("response"))
+	select {
+	case frame := <-stream.Inbox():
+		if got := string(frame.Payload); got != "response" {
+			t.Fatalf("v3 inbound payload = %q", got)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("v3 inbound data waited for flow-control credit")
+	}
+}
+
+func TestSessionOversizedWriteFailsBeforeCreditWait(t *testing.T) {
+	_, sess := newDispatchTestSession(t, 1)
+	sess.NegotiatedVersion = 4
+	stream := sess.OpenStream()
+	if err := stream.WriteDAT(make([]byte, protocol.MaxChunkSize+1)); err == nil {
+		t.Fatal("oversized v4 write did not fail")
+	}
+}
+
+func TestSessionOpenStreamAfterCloseIsNotRegistered(t *testing.T) {
+	_, sess := newDispatchTestSession(t, 1)
+	sess.Close()
+	stream := sess.OpenStream()
+	if got := sess.findStream(stream.ID()); got != nil {
+		t.Fatal("OpenStream registered a stream after session close")
+	}
+	if _, ok := <-stream.Inbox(); ok {
+		t.Fatal("post-close stream inbox remained open")
+	}
+	if err := stream.WriteSYN([]byte(`{"type":"test"}`)); err == nil {
+		t.Fatal("post-close stream write succeeded")
+	}
+}
+
+func TestSessionSlowStreamDoesNotBlockAnotherStream(t *testing.T) {
+	p, sess := newDispatchTestSession(t, protocol.MaxQueuedStreamFrames+2)
+	slow := sess.OpenStream()
+	fast := sess.OpenStream()
+	sess.startDispatcher(p)
+
+	for i := 0; i < protocol.MaxQueuedStreamFrames; i++ {
+		p.dcMsg <- protocol.BuildFrame(slow.ID(), protocol.FlagDAT, []byte{byte(i)})
+	}
+	p.dcMsg <- protocol.BuildFrame(fast.ID(), protocol.FlagDAT, []byte("ready"))
+
+	select {
+	case frame := <-fast.Inbox():
+		if got := string(frame.Payload); got != "ready" {
+			t.Fatalf("fast stream payload = %q, want ready", got)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("fast stream was blocked behind a full slow stream")
+	}
+}
+
+func TestSessionQueueOverflowClosesOnlyOffendingStream(t *testing.T) {
+	p, sess := newDispatchTestSession(t, protocol.MaxQueuedStreamFrames+3)
+	slow := sess.OpenStream()
+	fast := sess.OpenStream()
+	sess.startDispatcher(p)
+
+	for i := 0; i <= protocol.MaxQueuedStreamFrames; i++ {
+		p.dcMsg <- protocol.BuildFrame(slow.ID(), protocol.FlagDAT, []byte{byte(i)})
+	}
+	p.dcMsg <- protocol.BuildFrame(fast.ID(), protocol.FlagDAT, []byte("still-live"))
+
+	select {
+	case frame := <-fast.Inbox():
+		if got := string(frame.Payload); got != "still-live" {
+			t.Fatalf("fast stream payload = %q, want still-live", got)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("session stopped dispatching after another stream overflowed")
+	}
+
+	waitInboxClosed(t, slow.Inbox())
+	select {
+	case <-sess.Done():
+		t.Fatal("stream overflow closed the whole session")
+	default:
+	}
+}
+
+func TestSessionReceiveQueueHasByteLimit(t *testing.T) {
+	_, sess := newDispatchTestSession(t, 1)
+	st := sess.OpenStream().st
+	st.prepareInitialWindow()
+
+	frame := protocol.Frame{StreamID: st.id, Payload: make([]byte, protocol.MaxChunkSize)}
+	for i := 0; i < protocol.InitialStreamWindow/protocol.MaxChunkSize; i++ {
+		if err := st.enqueue(frame, true); err != nil {
+			t.Fatalf("enqueue frame %d: %v", i, err)
+		}
+	}
+	if err := st.enqueue(protocol.Frame{StreamID: st.id, Payload: []byte{1}}, true); !errors.Is(err, errReceiveWindowExceeded) {
+		t.Fatalf("over-window enqueue error = %v, want %v", err, errReceiveWindowExceeded)
+	}
+}
+
+func TestSessionDataChannelCloseWakesFullStream(t *testing.T) {
+	p, sess := newDispatchTestSession(t, protocol.MaxQueuedStreamFrames)
 	stream := sess.OpenStream()
 	sess.startDispatcher(p)
 
-	for i := 0; i < cap(stream.Inbox())+1; i++ {
+	for i := 0; i < protocol.MaxQueuedStreamFrames; i++ {
 		p.dcMsg <- protocol.BuildFrame(stream.ID(), protocol.FlagDAT, []byte{byte(i)})
 	}
-	deadline := time.Now().Add(time.Second)
-	for len(stream.Inbox()) != cap(stream.Inbox()) || len(p.dcMsg) != 0 {
-		if time.Now().After(deadline) {
-			t.Fatalf("inbox length = %d, queued messages = %d; want full inbox and blocked delivery", len(stream.Inbox()), len(p.dcMsg))
-		}
-		time.Sleep(time.Millisecond)
-	}
+	waitFor(t, func() bool { return len(p.dcMsg) == 0 }, "dispatcher to drain its input queue")
 
 	close(p.dcClosed)
 	select {
 	case <-sess.Done():
 	case <-time.After(time.Second):
 		t.Fatal("session remained open after data channel closure")
+	}
+	waitInboxClosed(t, stream.Inbox())
+}
+
+func TestSessionFINKeepsOppositeDirectionRoutable(t *testing.T) {
+	p, sess := newDispatchTestSession(t, 1)
+	sess.NegotiatedVersion = 4
+	stream := sess.OpenStream()
+	stream.st.prepareInitialWindow()
+	sess.startDispatcher(p)
+
+	p.dcMsg <- protocol.BuildFrame(stream.ID(), protocol.FlagFIN, nil)
+	select {
+	case frame, ok := <-stream.Inbox():
+		if !ok || !frame.IsFIN() {
+			t.Fatalf("inbound frame = %#v, open = %v; want FIN", frame, ok)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for FIN")
+	}
+	if _, ok := <-stream.Inbox(); ok {
+		t.Fatal("inbox remained open after FIN")
+	}
+	if got := sess.findStream(stream.ID()); got != stream.st {
+		t.Fatal("inbound FIN removed state for the still-open outbound direction")
+	}
+
+	stream.st.outboundFIN.Store(true)
+	sess.detachFinishedStream(stream.st)
+	if got := sess.findStream(stream.ID()); got != nil {
+		t.Fatal("stream state remained after both directions finished")
+	}
+}
+
+func TestSessionDataAfterFINResetsOnlyOffendingStream(t *testing.T) {
+	p, sess := newDispatchTestSession(t, 2)
+	sess.NegotiatedVersion = 4
+	sent := make(chan protocol.Frame, 1)
+	sess.sendFrameOverride = func(streamID uint32, flags uint16, payload []byte) error {
+		sent <- protocol.Frame{StreamID: streamID, Flags: flags, Payload: append([]byte(nil), payload...)}
+		return nil
+	}
+	stream := sess.OpenStream()
+	stream.st.prepareInitialWindow()
+	sess.startDispatcher(p)
+
+	blockedSend := make(chan error, 1)
+	go func() { blockedSend <- stream.st.reserveSend(1, sess.Done()) }()
+	assertBlocked(t, blockedSend)
+
+	p.dcMsg <- protocol.BuildFrame(stream.ID(), protocol.FlagFIN, nil)
+	p.dcMsg <- protocol.BuildFrame(stream.ID(), protocol.FlagDAT, []byte("late"))
+	if err := waitResult(t, blockedSend); err == nil {
+		t.Fatal("post-FIN protocol error did not wake blocked sender")
+	}
+
+	select {
+	case frame := <-sent:
+		var reset protocol.StreamReset
+		if frame.StreamID != 0 || json.Unmarshal(frame.Payload, &reset) != nil ||
+			reset.Type != protocol.ControlStreamReset || reset.StreamID != stream.ID() ||
+			reset.Code != "protocol_error" {
+			t.Fatalf("post-FIN reset = frame %#v reset %#v", frame, reset)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("post-FIN data did not notify peer")
+	}
+	waitInboxClosed(t, stream.Inbox())
+	select {
+	case <-sess.Done():
+		t.Fatal("post-FIN data closed the whole session")
+	default:
+	}
+}
+
+func TestSessionOwnsStreamUntilQueuedFINIsDelivered(t *testing.T) {
+	p, sess := newDispatchTestSession(t, 2)
+	sess.NegotiatedVersion = 4
+	sess.sendFrameOverride = func(uint32, uint16, []byte) error { return nil }
+	stream := sess.OpenStream()
+	stream.st.prepareInitialWindow()
+	sess.startDispatcher(p)
+
+	// Leave the public inbox unread so the delivery worker is blocked on the
+	// data frame while the dispatcher queues FIN behind it.
+	p.dcMsg <- protocol.BuildFrame(stream.ID(), protocol.FlagDAT, []byte("queued"))
+	p.dcMsg <- protocol.BuildFrame(stream.ID(), protocol.FlagFIN, nil)
+	waitFor(t, func() bool { return stream.st.inboundFIN.Load() }, "dispatcher to queue FIN")
+
+	if err := stream.WriteFIN(nil); err != nil {
+		t.Fatalf("WriteFIN: %v", err)
+	}
+	if got := sess.findStream(stream.ID()); got != stream.st {
+		t.Fatal("stream detached before queued FIN reached its consumer")
+	}
+
+	sess.Close()
+	select {
+	case <-stream.st.abandoned:
+	case <-time.After(time.Second):
+		t.Fatal("session close could not reach stream with queued FIN")
+	}
+	waitInboxClosed(t, stream.Inbox())
+}
+
+func TestStreamSendCreditIsCumulativeAndTeardownSafe(t *testing.T) {
+	_, sess := newDispatchTestSession(t, 1)
+	st := sess.OpenStream().st
+
+	result := make(chan error, 1)
+	go func() { result <- st.reserveSend(10, sess.Done()) }()
+	assertBlocked(t, result)
+
+	st.updateSendLimit(10)
+	if err := waitResult(t, result); err != nil {
+		t.Fatalf("reserve initial credit: %v", err)
+	}
+
+	go func() { result <- st.reserveSend(1, sess.Done()) }()
+	st.updateSendLimit(5) // stale update must not reduce or replenish credit
+	assertBlocked(t, result)
+	st.updateSendLimit(11)
+	if err := waitResult(t, result); err != nil {
+		t.Fatalf("reserve replenished credit: %v", err)
+	}
+
+	go func() { result <- st.reserveSend(1, sess.Done()) }()
+	assertBlocked(t, result)
+	sess.Close()
+	if err := waitResult(t, result); err == nil {
+		t.Fatal("blocked send returned nil after session close")
+	}
+}
+
+func TestSessionHandlesWindowUpdateAndStreamReset(t *testing.T) {
+	_, sess := newDispatchTestSession(t, 1)
+	sess.NegotiatedVersion = 4
+	stream := sess.OpenStream()
+
+	update, _ := json.Marshal(protocol.WindowUpdate{
+		Type:     protocol.ControlWindowUpdate,
+		StreamID: stream.ID(),
+		MaxBytes: 123,
+	})
+	if !sess.handleControl(protocol.Frame{StreamID: 0, Flags: protocol.FlagSYN, Payload: update}) {
+		t.Fatal("window update was not handled")
+	}
+	if err := stream.st.reserveSend(123, sess.Done()); err != nil {
+		t.Fatalf("reserve updated window: %v", err)
+	}
+
+	reset, _ := json.Marshal(protocol.StreamReset{
+		Type:     protocol.ControlStreamReset,
+		StreamID: stream.ID(),
+		Code:     "peer_error",
+		Message:  "target closed",
+	})
+	if !sess.handleControl(protocol.Frame{StreamID: 0, Flags: protocol.FlagSYN, Payload: reset}) {
+		t.Fatal("stream reset was not handled")
+	}
+	waitInboxClosed(t, stream.Inbox())
+	if err := stream.st.reserveSend(1, sess.Done()); err == nil || err.Error() != "target closed" {
+		t.Fatalf("send after reset error = %v, want target closed", err)
+	}
+	select {
+	case <-sess.Done():
+		t.Fatal("stream reset closed the whole session")
+	default:
+	}
+}
+
+func TestSessionMalformedControlResetsKnownStream(t *testing.T) {
+	_, sess := newDispatchTestSession(t, 1)
+	sess.NegotiatedVersion = 4
+	stream := sess.OpenStream()
+	payload := []byte(`{"type":"window_update","stream_id":1,"max_bytes":"invalid"}`)
+
+	if !sess.handleControl(protocol.Frame{StreamID: 0, Flags: protocol.FlagSYN, Payload: payload}) {
+		t.Fatal("malformed window update was not handled")
+	}
+	waitInboxClosed(t, stream.Inbox())
+	if got := sess.findStream(stream.ID()); got != nil {
+		t.Fatal("malformed control left its target stream active")
+	}
+	select {
+	case <-sess.Done():
+		t.Fatal("malformed stream control closed the whole session")
+	default:
+	}
+}
+
+func TestStreamCloseNotifiesPeerWhenOutboundDirectionIsOpen(t *testing.T) {
+	for _, tt := range []struct {
+		name    string
+		version int
+	}{
+		{name: "legacy FIN", version: 3},
+		{name: "v4 reset", version: 4},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			_, sess := newDispatchTestSession(t, 1)
+			sess.NegotiatedVersion = tt.version
+			sent := make(chan protocol.Frame, 2)
+			sess.sendFrameOverride = func(streamID uint32, flags uint16, payload []byte) error {
+				sent <- protocol.Frame{StreamID: streamID, Flags: flags, Payload: append([]byte(nil), payload...)}
+				return nil
+			}
+			stream := sess.OpenStream()
+
+			stream.Close()
+			var frame protocol.Frame
+			select {
+			case frame = <-sent:
+			case <-time.After(time.Second):
+				t.Fatal("Stream.Close did not notify peer")
+			}
+			if tt.version < 4 {
+				if frame.StreamID != stream.ID() || !frame.IsFIN() || len(frame.Payload) != 0 {
+					t.Fatalf("legacy close frame = %#v, want empty stream FIN", frame)
+				}
+			} else {
+				if frame.StreamID != 0 || !frame.IsSYN() {
+					t.Fatalf("v4 close frame = %#v, want stream-0 SYN", frame)
+				}
+				var reset protocol.StreamReset
+				if err := json.Unmarshal(frame.Payload, &reset); err != nil {
+					t.Fatalf("parse reset: %v", err)
+				}
+				if reset.Type != protocol.ControlStreamReset || reset.StreamID != stream.ID() {
+					t.Fatalf("reset = %#v, want stream %d reset", reset, stream.ID())
+				}
+			}
+
+			// Close is idempotent and must not emit duplicate terminal controls.
+			stream.Close()
+			select {
+			case duplicate := <-sent:
+				t.Fatalf("second Stream.Close sent %#v", duplicate)
+			case <-time.After(20 * time.Millisecond):
+			}
+			if err := stream.WriteDAT([]byte("late")); err == nil {
+				t.Fatal("detached stream accepted a later write")
+			}
+		})
+	}
+}
+
+func TestV4StreamCloseCancelsResponseAfterOutboundFIN(t *testing.T) {
+	_, sess := newDispatchTestSession(t, 1)
+	sess.NegotiatedVersion = 4
+	sent := make(chan protocol.Frame, 1)
+	sess.sendFrameOverride = func(streamID uint32, flags uint16, payload []byte) error {
+		sent <- protocol.Frame{StreamID: streamID, Flags: flags, Payload: append([]byte(nil), payload...)}
+		return nil
+	}
+	stream := sess.OpenStream()
+	stream.st.outboundFIN.Store(true)
+
+	stream.Close()
+	select {
+	case frame := <-sent:
+		var reset protocol.StreamReset
+		if frame.StreamID != 0 || json.Unmarshal(frame.Payload, &reset) != nil ||
+			reset.Type != protocol.ControlStreamReset || reset.StreamID != stream.ID() {
+			t.Fatalf("close frame = %#v reset = %#v, want v4 reset", frame, reset)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("Stream.Close did not cancel in-flight response")
+	}
+}
+
+func TestStreamResetFollowsAlreadyReservedData(t *testing.T) {
+	_, sess := newDispatchTestSession(t, 1)
+	sess.NegotiatedVersion = 4
+	stream := sess.OpenStream()
+	stream.st.updateSendLimit(1)
+
+	dataStarted := make(chan struct{})
+	releaseData := make(chan struct{})
+	events := make(chan string, 2)
+	sess.sendFrameOverride = func(streamID uint32, _ uint16, _ []byte) error {
+		if streamID == stream.ID() {
+			close(dataStarted)
+			<-releaseData
+			events <- "data"
+			return nil
+		}
+		events <- "reset"
+		return nil
+	}
+
+	writeDone := make(chan error, 1)
+	go func() { writeDone <- stream.WriteDAT([]byte("x")) }()
+	select {
+	case <-dataStarted:
+	case <-time.After(time.Second):
+		t.Fatal("data send did not start")
+	}
+	sess.failStream(stream.st, "test_reset", "reset", true)
+	select {
+	case event := <-events:
+		t.Fatalf("terminal event %q overtook blocked data", event)
+	case <-time.After(20 * time.Millisecond):
+	}
+
+	close(releaseData)
+	if err := waitResult(t, writeDone); err != nil {
+		t.Fatalf("in-flight data send: %v", err)
+	}
+	for _, want := range []string{"data", "reset"} {
+		select {
+		case got := <-events:
+			if got != want {
+				t.Fatalf("send order = %q before %q", got, want)
+			}
+		case <-time.After(time.Second):
+			t.Fatalf("timed out waiting for %s send", want)
+		}
+	}
+}
+
+func newDispatchTestSession(t *testing.T, messageBuffer int) (*Peer, *Session) {
+	t.Helper()
+	p := &Peer{
+		dcMsg:    make(chan []byte, messageBuffer),
+		dcClosed: make(chan struct{}),
+	}
+	sess := newSession(p)
+	t.Cleanup(sess.Close)
+	return p, sess
+}
+
+func waitInboxClosed(t *testing.T, inbox <-chan protocol.Frame) {
+	t.Helper()
+	done := make(chan struct{})
+	go func() {
+		for range inbox {
+		}
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("stream inbox remained open")
+	}
+}
+
+func waitFor(t *testing.T, condition func() bool, description string) {
+	t.Helper()
+	deadline := time.Now().Add(time.Second)
+	for !condition() {
+		if time.Now().After(deadline) {
+			t.Fatalf("timed out waiting for %s", description)
+		}
+		time.Sleep(time.Millisecond)
+	}
+}
+
+func assertBlocked(t *testing.T, result <-chan error) {
+	t.Helper()
+	select {
+	case err := <-result:
+		t.Fatalf("operation returned early: %v", err)
+	case <-time.After(20 * time.Millisecond):
+	}
+}
+
+func waitResult(t *testing.T, result <-chan error) error {
+	t.Helper()
+	select {
+	case err := <-result:
+		return err
+	case <-time.After(time.Second):
+		t.Fatal("operation did not finish")
+		return nil
 	}
 }

--- a/internal/client/session_test.go
+++ b/internal/client/session_test.go
@@ -82,6 +82,94 @@ func TestSessionV3DataPathDoesNotUseCredit(t *testing.T) {
 	}
 }
 
+func TestSessionV4DataUsesImplicitInitialWindow(t *testing.T) {
+	p, sess := newDispatchTestSession(t, 1)
+	sess.NegotiatedVersion = 4
+	sent := make(chan protocol.Frame, 3)
+	sess.sendFrameOverride = func(streamID uint32, flags uint16, payload []byte) error {
+		sent <- protocol.Frame{StreamID: streamID, Flags: flags, Payload: append([]byte(nil), payload...)}
+		return nil
+	}
+	stream := sess.OpenStream()
+	sess.startDispatcher(p)
+	writeDone := make(chan error, 1)
+	go func() { writeDone <- stream.WriteSYN([]byte(`{"type":"test"}`)) }()
+	if err := waitResult(t, writeDone); err != nil {
+		t.Fatalf("v4 WriteSYN: %v", err)
+	}
+	go func() { writeDone <- stream.WriteDAT([]byte("request")) }()
+	if err := waitResult(t, writeDone); err != nil {
+		t.Fatalf("v4 first WriteDAT: %v", err)
+	}
+
+	for i := 0; i < 2; i++ {
+		select {
+		case frame := <-sent:
+			if frame.StreamID != stream.ID() {
+				t.Fatalf("v4 sent initial control frame: %#v", frame)
+			}
+		case <-time.After(time.Second):
+			t.Fatal("timed out waiting for v4 stream frame")
+		}
+	}
+	select {
+	case frame := <-sent:
+		t.Fatalf("v4 sent redundant initial control frame: %#v", frame)
+	case <-time.After(20 * time.Millisecond):
+	}
+
+	p.dcMsg <- protocol.BuildFrame(stream.ID(), protocol.FlagDAT, []byte("response"))
+	select {
+	case frame := <-stream.Inbox():
+		if got := string(frame.Payload); got != "response" {
+			t.Fatalf("v4 immediate response = %q, want response", got)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("v4 immediate response was not accepted")
+	}
+}
+
+func TestSessionV4RejectsDataBeforeSYN(t *testing.T) {
+	_, sess := newDispatchTestSession(t, 1)
+	sess.NegotiatedVersion = 4
+	sent := make(chan protocol.Frame, 1)
+	sess.sendFrameOverride = func(streamID uint32, flags uint16, payload []byte) error {
+		sent <- protocol.Frame{StreamID: streamID, Flags: flags, Payload: append([]byte(nil), payload...)}
+		return nil
+	}
+	stream := sess.OpenStream()
+
+	if err := stream.WriteDAT([]byte("early")); !errors.Is(err, errStreamNotStarted) {
+		t.Fatalf("pre-SYN WriteDAT error = %v, want %v", err, errStreamNotStarted)
+	}
+	frame := protocol.Frame{StreamID: stream.ID(), Payload: []byte("early")}
+	if err := stream.st.enqueue(frame, true); !errors.Is(err, errStreamNotStarted) {
+		t.Fatalf("pre-SYN inbound DAT error = %v, want %v", err, errStreamNotStarted)
+	}
+	select {
+	case frame := <-sent:
+		t.Fatalf("pre-SYN WriteDAT sent frame %#v", frame)
+	case <-time.After(20 * time.Millisecond):
+	}
+}
+
+func TestSessionFailedV4SYNClosesStream(t *testing.T) {
+	_, sess := newDispatchTestSession(t, 1)
+	sess.NegotiatedVersion = 4
+	sess.sendFrameOverride = func(uint32, uint16, []byte) error {
+		return errors.New("send failed")
+	}
+	stream := sess.OpenStream()
+
+	if err := stream.WriteSYN([]byte(`{"type":"test"}`)); err == nil || err.Error() != "send failed" {
+		t.Fatalf("failed SYN error = %v, want send failed", err)
+	}
+	if got := sess.findStream(stream.ID()); got != nil {
+		t.Fatal("failed SYN left stream registered")
+	}
+	waitInboxClosed(t, stream.Inbox())
+}
+
 func TestSessionOversizedWriteFailsBeforeCreditWait(t *testing.T) {
 	_, sess := newDispatchTestSession(t, 1)
 	sess.NegotiatedVersion = 4
@@ -157,8 +245,9 @@ func TestSessionQueueOverflowClosesOnlyOffendingStream(t *testing.T) {
 
 func TestSessionReceiveQueueHasByteLimit(t *testing.T) {
 	_, sess := newDispatchTestSession(t, 1)
+	sess.NegotiatedVersion = 4
 	st := sess.OpenStream().st
-	st.prepareInitialWindow()
+	st.activateInitialWindow()
 
 	frame := protocol.Frame{StreamID: st.id, Payload: make([]byte, protocol.MaxChunkSize)}
 	for i := 0; i < protocol.InitialStreamWindow/protocol.MaxChunkSize; i++ {
@@ -194,7 +283,7 @@ func TestSessionFINKeepsOppositeDirectionRoutable(t *testing.T) {
 	p, sess := newDispatchTestSession(t, 1)
 	sess.NegotiatedVersion = 4
 	stream := sess.OpenStream()
-	stream.st.prepareInitialWindow()
+	stream.st.activateInitialWindow()
 	sess.startDispatcher(p)
 
 	p.dcMsg <- protocol.BuildFrame(stream.ID(), protocol.FlagFIN, nil)
@@ -229,9 +318,12 @@ func TestSessionDataAfterFINResetsOnlyOffendingStream(t *testing.T) {
 		return nil
 	}
 	stream := sess.OpenStream()
-	stream.st.prepareInitialWindow()
+	stream.st.activateInitialWindow()
 	sess.startDispatcher(p)
 
+	if err := stream.st.reserveSend(protocol.InitialStreamWindow, sess.Done()); err != nil {
+		t.Fatalf("reserve implicit initial window: %v", err)
+	}
 	blockedSend := make(chan error, 1)
 	go func() { blockedSend <- stream.st.reserveSend(1, sess.Done()) }()
 	assertBlocked(t, blockedSend)
@@ -266,7 +358,7 @@ func TestSessionOwnsStreamUntilQueuedFINIsDelivered(t *testing.T) {
 	sess.NegotiatedVersion = 4
 	sess.sendFrameOverride = func(uint32, uint16, []byte) error { return nil }
 	stream := sess.OpenStream()
-	stream.st.prepareInitialWindow()
+	stream.st.activateInitialWindow()
 	sess.startDispatcher(p)
 
 	// Leave the public inbox unread so the delivery worker is blocked on the
@@ -293,21 +385,19 @@ func TestSessionOwnsStreamUntilQueuedFINIsDelivered(t *testing.T) {
 
 func TestStreamSendCreditIsCumulativeAndTeardownSafe(t *testing.T) {
 	_, sess := newDispatchTestSession(t, 1)
+	sess.NegotiatedVersion = 4
 	st := sess.OpenStream().st
+	st.activateInitialWindow()
 
-	result := make(chan error, 1)
-	go func() { result <- st.reserveSend(10, sess.Done()) }()
-	assertBlocked(t, result)
-
-	st.updateSendLimit(10)
-	if err := waitResult(t, result); err != nil {
-		t.Fatalf("reserve initial credit: %v", err)
+	if err := st.reserveSend(protocol.InitialStreamWindow, sess.Done()); err != nil {
+		t.Fatalf("reserve implicit initial credit: %v", err)
 	}
 
+	result := make(chan error, 1)
 	go func() { result <- st.reserveSend(1, sess.Done()) }()
-	st.updateSendLimit(5) // stale update must not reduce or replenish credit
+	st.updateSendLimit(protocol.InitialStreamWindow - 1) // stale update must not reduce credit
 	assertBlocked(t, result)
-	st.updateSendLimit(11)
+	st.updateSendLimit(protocol.InitialStreamWindow + 1)
 	if err := waitResult(t, result); err != nil {
 		t.Fatalf("reserve replenished credit: %v", err)
 	}
@@ -324,16 +414,17 @@ func TestSessionHandlesWindowUpdateAndStreamReset(t *testing.T) {
 	_, sess := newDispatchTestSession(t, 1)
 	sess.NegotiatedVersion = 4
 	stream := sess.OpenStream()
+	stream.st.activateInitialWindow()
 
 	update, _ := json.Marshal(protocol.WindowUpdate{
 		Type:     protocol.ControlWindowUpdate,
 		StreamID: stream.ID(),
-		MaxBytes: 123,
+		MaxBytes: protocol.InitialStreamWindow + 123,
 	})
 	if !sess.handleControl(protocol.Frame{StreamID: 0, Flags: protocol.FlagSYN, Payload: update}) {
 		t.Fatal("window update was not handled")
 	}
-	if err := stream.st.reserveSend(123, sess.Done()); err != nil {
+	if err := stream.st.reserveSend(protocol.InitialStreamWindow+123, sess.Done()); err != nil {
 		t.Fatalf("reserve updated window: %v", err)
 	}
 
@@ -461,7 +552,7 @@ func TestStreamResetFollowsAlreadyReservedData(t *testing.T) {
 	_, sess := newDispatchTestSession(t, 1)
 	sess.NegotiatedVersion = 4
 	stream := sess.OpenStream()
-	stream.st.updateSendLimit(1)
+	stream.st.activateInitialWindow()
 
 	dataStarted := make(chan struct{})
 	releaseData := make(chan struct{})

--- a/internal/client/tcp.go
+++ b/internal/client/tcp.go
@@ -144,6 +144,18 @@ func (f *LocalForwarder) forward(conn net.Conn, forward tcpforward.Forward) erro
 
 	ctx, cancel := context.WithCancel(f.ctx)
 	defer cancel()
+	watchDone := make(chan struct{})
+	defer close(watchDone)
+	go func() {
+		select {
+		case <-ctx.Done():
+			// A v4 data write may be waiting for stream credit. Closing the
+			// local socket alone cannot wake that wait; abandoning the stream can.
+			st.Close()
+			_ = conn.Close()
+		case <-watchDone:
+		}
+	}()
 	done := make(chan error, 2)
 	go func() {
 		_, err := bytestream.Pump(ctx, conn, st)

--- a/internal/client/tcp_e2e_test.go
+++ b/internal/client/tcp_e2e_test.go
@@ -2,6 +2,8 @@ package client
 
 import (
 	"bytes"
+	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net"
@@ -193,6 +195,174 @@ func TestSession_TCPForwardingEndToEnd(t *testing.T) {
 	if conn, err := net.DialTimeout("tcp4", fmt.Sprintf("127.0.0.1:%d", goodLocal), 100*time.Millisecond); err == nil {
 		_ = conn.Close()
 		t.Fatal("local listener survived session teardown")
+	}
+}
+
+func TestSession_TCPFlowControlIsolatesStalledStream(t *testing.T) {
+	if testing.Short() {
+		t.Skip("e2e: spins up real pion peer connections, a TCP stream, and a shell process")
+	}
+
+	listenerConn, targetConn := net.Pipe()
+	t.Cleanup(func() {
+		_ = listenerConn.Close()
+		_ = targetConn.Close()
+	})
+
+	tcpHandler := streamtype.NewTCP(false)
+	dialed := make(chan struct{})
+	var dialOnce sync.Once
+	tcpHandler.DialContext = func(context.Context, string, string) (net.Conn, error) {
+		dialOnce.Do(func() { close(dialed) })
+		return listenerConn, nil
+	}
+
+	id := ephemeralID(t)
+	relay := newFakeSignaling()
+	t.Cleanup(relay.Close)
+	startListener(relay.host(), id, streamtype.NewShell(nil, false), tcpHandler)
+	waitRegistered(t, relay)
+	sess := mustDial(t, relay.host(), id, "shell", "tcp")
+	t.Cleanup(sess.Close)
+	if sess.NegotiatedVersion != protocol.SWSPVersion {
+		t.Fatalf("negotiated version = %d, want %d", sess.NegotiatedVersion, protocol.SWSPVersion)
+	}
+
+	stalled := sess.OpenStream()
+	defer stalled.Close()
+	syn, _ := json.Marshal(protocol.TCPOpen{Type: "tcp", Host: "stalled.test", Port: 9000})
+	if err := stalled.WriteSYN(syn); err != nil {
+		t.Fatalf("open stalled TCP stream: %v", err)
+	}
+	select {
+	case <-dialed:
+	case <-time.After(2 * time.Second):
+		t.Fatal("listener did not dial stalled target")
+	}
+	select {
+	case frame := <-stalled.Inbox():
+		if !frame.IsSYN() || frame.IsFIN() {
+			t.Fatalf("TCP response flags = %#x, want SYN", frame.Flags)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for TCP response")
+	}
+
+	chunk := make([]byte, bytestream.FrameSize)
+	for sent := 0; sent < protocol.InitialStreamWindow; sent += len(chunk) {
+		if err := stalled.WriteDAT(chunk); err != nil {
+			t.Fatalf("fill stalled stream window at %d bytes: %v", sent, err)
+		}
+	}
+
+	blockedWrite := make(chan error, 1)
+	go func() { blockedWrite <- stalled.WriteDAT(chunk) }()
+	select {
+	case err := <-blockedWrite:
+		t.Fatalf("write beyond stalled stream window returned early: %v", err)
+	case <-time.After(150 * time.Millisecond):
+	}
+
+	shellInR, shellInW := io.Pipe()
+	shellOutR, shellOutW := io.Pipe()
+	defer shellInR.Close()
+	defer shellInW.Close()
+	defer shellOutR.Close()
+	defer shellOutW.Close()
+
+	type shellResult struct {
+		result *ShellResult
+		err    error
+	}
+	shellDone := make(chan shellResult, 1)
+	argv := shellHelperArgv(t, "cat")
+	go func() {
+		result, err := sess.Shell(ShellOptions{
+			Argv:   argv,
+			Env:    map[string]string{shellHelperEnv: "1"},
+			Stdin:  shellInR,
+			Stdout: shellOutW,
+		})
+		shellDone <- shellResult{result: result, err: err}
+	}()
+
+	marker := []byte("shell-progress-42")
+	writeDone := make(chan error, 1)
+	go func() {
+		_, err := shellInW.Write(marker)
+		writeDone <- err
+	}()
+	readDone := make(chan error, 1)
+	go func() {
+		got := make([]byte, len(marker))
+		_, err := io.ReadFull(shellOutR, got)
+		if err == nil && !bytes.Equal(got, marker) {
+			err = fmt.Errorf("shell output %q, want %q", got, marker)
+		}
+		readDone <- err
+	}()
+	select {
+	case err := <-readDone:
+		if err != nil {
+			t.Fatalf("shell while TCP stream stalled: %v", err)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("shell stream blocked behind stalled TCP stream")
+	}
+	select {
+	case err := <-writeDone:
+		if err != nil {
+			t.Fatalf("write shell marker: %v", err)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("shell input write did not complete")
+	}
+	_ = shellInW.Close()
+	select {
+	case got := <-shellDone:
+		if got.err != nil {
+			t.Fatalf("close shell while TCP stream stalled: %v", got.err)
+		}
+		if got.result.ExitCode != 0 {
+			t.Fatalf("shell while TCP stream stalled exit = %d, want 0", got.result.ExitCode)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("shell did not exit after stdin closed")
+	}
+
+	drainDone := make(chan error, 1)
+	go func() {
+		_, err := io.CopyN(io.Discard, targetConn, int64(protocol.InitialStreamWindow+len(chunk)))
+		drainDone <- err
+	}()
+	select {
+	case err := <-blockedWrite:
+		if err != nil {
+			t.Fatalf("stalled TCP write after target resumed: %v", err)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("stalled TCP write did not resume after target drained")
+	}
+	if err := stalled.WriteFIN(nil); err != nil {
+		t.Fatalf("close stalled TCP write direction: %v", err)
+	}
+	select {
+	case err := <-drainDone:
+		if err != nil {
+			t.Fatalf("drain stalled target: %v", err)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("stalled target did not receive the complete payload")
+	}
+	_ = targetConn.Close()
+
+	select {
+	case frame, ok := <-stalled.Inbox():
+		if !ok || !frame.IsFIN() {
+			t.Fatalf("stalled TCP teardown frame = %#v, open=%v; want FIN", frame, ok)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("stalled TCP stream did not tear down")
 	}
 }
 

--- a/internal/protocol/swsp.go
+++ b/internal/protocol/swsp.go
@@ -42,9 +42,12 @@ const (
 	// v4 adds negotiated per-stream flow control and stream-local resets.
 	SWSPVersion = 4
 
-	// Flow-control defaults are deliberately per stream. Keeping the update
-	// threshold below the window lets a sender continue while the next
-	// cumulative grant is in flight.
+	// Flow-control defaults are deliberately per stream. A v4 SYN implicitly
+	// grants the initial window in both directions; later window updates raise
+	// that cumulative limit. Keeping the update threshold below the window lets
+	// a sender continue while the next grant is in flight. The frame limit
+	// separately bounds queue work for tiny or empty frames that consume little
+	// or no byte credit.
 	InitialStreamWindow         = 1 << 20
 	StreamWindowUpdateThreshold = InitialStreamWindow / 2
 	MaxQueuedStreamFrames       = 256

--- a/internal/protocol/swsp.go
+++ b/internal/protocol/swsp.go
@@ -39,8 +39,37 @@ const (
 	// stream-0 `connect` (client → device) and `ready` (device → client).
 	// v3 adds typed SYN payloads and capability negotiation while keeping
 	// the byte-level frame format unchanged from v2.
-	SWSPVersion = 3
+	// v4 adds negotiated per-stream flow control and stream-local resets.
+	SWSPVersion = 4
+
+	// Flow-control defaults are deliberately per stream. Keeping the update
+	// threshold below the window lets a sender continue while the next
+	// cumulative grant is in flight.
+	InitialStreamWindow         = 1 << 20
+	StreamWindowUpdateThreshold = InitialStreamWindow / 2
+	MaxQueuedStreamFrames       = 256
+
+	ControlWindowUpdate = "window_update"
+	ControlStreamReset  = "stream_reset"
 )
+
+// WindowUpdate raises the cumulative number of payload bytes the peer may
+// send in one direction of a stream. Updates are monotonic, which makes stale
+// or duplicate controls harmless.
+type WindowUpdate struct {
+	Type     string `json:"type"`
+	StreamID uint32 `json:"stream_id"`
+	MaxBytes uint64 `json:"max_bytes"`
+}
+
+// StreamReset terminates both directions of one stream without affecting the
+// other streams multiplexed over the data channel.
+type StreamReset struct {
+	Type     string `json:"type"`
+	StreamID uint32 `json:"stream_id"`
+	Code     string `json:"code,omitempty"`
+	Message  string `json:"message,omitempty"`
+}
 
 // Frame represents a single SWSP frame.
 type Frame struct {
@@ -95,8 +124,8 @@ func ParseFrame(data []byte) (Frame, error) {
 	flags := binary.LittleEndian.Uint16(data[4:6])
 	length := binary.LittleEndian.Uint16(data[6:8])
 
-	if len(data) < HeaderSize+int(length) {
-		return Frame{}, fmt.Errorf("frame truncated: expected %d payload bytes, got %d", length, len(data)-HeaderSize)
+	if len(data) != HeaderSize+int(length) {
+		return Frame{}, fmt.Errorf("frame length mismatch: expected %d payload bytes, got %d", length, len(data)-HeaderSize)
 	}
 
 	payload := make([]byte, length)
@@ -107,6 +136,16 @@ func ParseFrame(data []byte) (Frame, error) {
 		Flags:    flags,
 		Payload:  payload,
 	}, nil
+}
+
+// ValidateFramePayload rejects payloads that cannot be represented as one
+// bounded SWSP data-channel message. Callers must split larger byte streams
+// using their stream type's framing rules.
+func ValidateFramePayload(payload []byte) error {
+	if len(payload) > MaxChunkSize {
+		return fmt.Errorf("frame payload too large: %d bytes (max %d)", len(payload), MaxChunkSize)
+	}
+	return nil
 }
 
 // BuildFrame creates raw bytes for an SWSP frame.
@@ -128,6 +167,28 @@ func (f Frame) IsFIN() bool { return f.Flags&FlagFIN != 0 }
 // IsMORE returns true if the MORE flag is set, i.e. this DAT frame is a
 // non-final fragment of a chunked WebSocket message.
 func (f Frame) IsMORE() bool { return f.Flags&FlagMORE != 0 }
+
+// FlowBytes returns the number of bytes charged against a v4 receive window.
+// SYN metadata and empty FIN frames must remain sendable without credit so
+// stream setup and teardown cannot deadlock.
+func (f Frame) FlowBytes() uint64 {
+	if f.IsSYN() {
+		return 0
+	}
+	return uint64(len(f.Payload))
+}
+
+// NegotiateSWSPVersion selects the highest wire version supported by both
+// peers. A missing version is the legacy v2 wire format.
+func NegotiateSWSPVersion(peerVersion int) int {
+	if peerVersion <= 0 {
+		return 2
+	}
+	if peerVersion > SWSPVersion {
+		return SWSPVersion
+	}
+	return peerVersion
+}
 
 // ParseRequest parses the JSON payload of a SYN frame as a Request.
 func (f Frame) ParseRequest() (Request, error) {

--- a/internal/protocol/swsp_test.go
+++ b/internal/protocol/swsp_test.go
@@ -87,3 +87,66 @@ func TestParseFrameTooShort(t *testing.T) {
 		t.Error("expected error for short frame")
 	}
 }
+
+func TestParseFrameRejectsOversizedAndMismatchedPayloads(t *testing.T) {
+	// Accept a legacy peer's valid 16-bit frame even though new senders use
+	// the smaller MaxChunkSize bound.
+	legacy := BuildFrame(1, FlagDAT, make([]byte, MaxChunkSize+1))
+	if _, err := ParseFrame(legacy); err != nil {
+		t.Fatalf("ParseFrame rejected a legacy-sized payload: %v", err)
+	}
+
+	valid := BuildFrame(1, FlagDAT, []byte("ok"))
+	if _, err := ParseFrame(append(valid, 0)); err == nil {
+		t.Fatal("ParseFrame accepted trailing bytes")
+	}
+	if _, err := ParseFrame(valid[:len(valid)-1]); err == nil {
+		t.Fatal("ParseFrame accepted a truncated payload")
+	}
+	if err := ValidateFramePayload(make([]byte, MaxChunkSize+1)); err == nil {
+		t.Fatal("ValidateFramePayload accepted an oversized payload")
+	}
+}
+
+func TestFlowBytes(t *testing.T) {
+	tests := []struct {
+		name  string
+		frame Frame
+		want  uint64
+	}{
+		{name: "syn", frame: Frame{Flags: FlagSYN, Payload: []byte("metadata")}},
+		{name: "syn fin", frame: Frame{Flags: FlagSYN | FlagFIN, Payload: []byte("metadata")}},
+		{name: "dat", frame: Frame{Flags: FlagDAT, Payload: []byte("data")}, want: 4},
+		{name: "more", frame: Frame{Flags: FlagMORE, Payload: []byte("part")}, want: 4},
+		{name: "fin payload", frame: Frame{Flags: FlagFIN, Payload: []byte("tail")}, want: 4},
+		{name: "empty fin", frame: Frame{Flags: FlagFIN}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.frame.FlowBytes(); got != tt.want {
+				t.Fatalf("FlowBytes() = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNegotiateSWSPVersion(t *testing.T) {
+	tests := []struct {
+		peer int
+		want int
+	}{
+		{peer: -1, want: 2},
+		{peer: 0, want: 2},
+		{peer: 2, want: 2},
+		{peer: 3, want: 3},
+		{peer: 4, want: 4},
+		{peer: 99, want: SWSPVersion},
+	}
+
+	for _, tt := range tests {
+		if got := NegotiateSWSPVersion(tt.peer); got != tt.want {
+			t.Errorf("NegotiateSWSPVersion(%d) = %d, want %d", tt.peer, got, tt.want)
+		}
+	}
+}

--- a/internal/session/control.go
+++ b/internal/session/control.go
@@ -29,8 +29,33 @@ func (s *Session) handleControl(frame protocol.Frame) {
 		return
 	}
 
+	var envelope struct {
+		Type string `json:"type"`
+	}
+	if err := json.Unmarshal(frame.Payload, &envelope); err != nil {
+		return
+	}
+
+	switch envelope.Type {
+	case protocol.ControlWindowUpdate:
+		var update protocol.WindowUpdate
+		if err := json.Unmarshal(frame.Payload, &update); err != nil {
+			s.resetMalformedControl(frame.Payload, err)
+			return
+		}
+		s.applyWindowUpdate(update)
+		return
+	case protocol.ControlStreamReset:
+		var reset protocol.StreamReset
+		if err := json.Unmarshal(frame.Payload, &reset); err != nil {
+			s.resetMalformedControl(frame.Payload, err)
+			return
+		}
+		s.applyStreamReset(reset)
+		return
+	}
+
 	var msg struct {
-		Type      string                 `json:"type"`
 		Path      string                 `json:"path"`
 		PIN       string                 `json:"pin"`
 		Version   int                    `json:"version"`
@@ -41,7 +66,7 @@ func (s *Session) handleControl(frame protocol.Frame) {
 		return
 	}
 
-	switch msg.Type {
+	switch envelope.Type {
 	case "connect":
 		s.handleConnect(msg.Path, msg.Version)
 	case "auth":
@@ -63,7 +88,7 @@ func (s *Session) handleControl(frame protocol.Frame) {
 	}
 }
 
-func (s *Session) handleConnect(path string, _ int) {
+func (s *Session) handleConnect(path string, peerVersion int) {
 	if path == "" {
 		path = "/"
 	}
@@ -81,6 +106,15 @@ func (s *Session) handleConnect(path string, _ int) {
 			return
 		}
 	}
+
+	// Lock the transport semantics after the first accepted connect. Browser
+	// navigation can send another connect to update routing, but changing flow
+	// control while streams are live would make byte accounting ambiguous.
+	s.mu.Lock()
+	if s.negotiatedVersion == 0 {
+		s.negotiatedVersion = protocol.NegotiateSWSPVersion(peerVersion)
+	}
+	s.mu.Unlock()
 
 	if s.PIN.Required() {
 		log.Printf("PIN required for connection")
@@ -159,11 +193,15 @@ func (s *Session) sendReady() {
 	// cookies between different LAN hosts reached through the same UID;
 	// direct adapters (bitbang-python's WSGI/ASGI) declare "direct"
 	// instead, and everything under one UID shares a cookie jar.
+	s.mu.Lock()
+	negotiatedVersion := s.negotiatedVersion
+	s.mu.Unlock()
 	ready, _ := json.Marshal(map[string]interface{}{
-		"type":           "ready",
-		"server_version": protocol.SWSPVersion,
-		"caps":           caps,
-		"routing":        "target-prefix",
+		"type":               "ready",
+		"server_version":     protocol.SWSPVersion,
+		"negotiated_version": negotiatedVersion,
+		"caps":               caps,
+		"routing":            "target-prefix",
 	})
 	_ = s.sendFrame(0, protocol.FlagSYN|protocol.FlagFIN, ready)
 

--- a/internal/session/flow.go
+++ b/internal/session/flow.go
@@ -1,0 +1,435 @@
+package session
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sync"
+
+	"github.com/richlegrand/bitbang/internal/protocol"
+	"github.com/richlegrand/bitbang/internal/streamtype"
+)
+
+var (
+	errStreamClosed   = errors.New("stream closed")
+	errStreamFinished = errors.New("stream direction already finished")
+)
+
+type streamReceiveError struct {
+	code    string
+	message string
+}
+
+func (e *streamReceiveError) Error() string { return e.message }
+
+func receiveErrorCode(err error) string {
+	var receiveErr *streamReceiveError
+	if errors.As(err, &receiveErr) {
+		return receiveErr.code
+	}
+	return "receive_overflow"
+}
+
+// streamState owns one stream's ordering, receive bounds, and directional
+// flow-control counters. Its queue is never written with a blocking send.
+type streamState struct {
+	id      uint32
+	handler streamtype.StreamHandler
+	flow    bool
+	queue   chan protocol.Frame
+	done    chan struct{}
+	stop    sync.Once
+
+	mu               sync.Mutex
+	closed           bool
+	queuedBytes      int
+	queuedFrames     int
+	received         uint64
+	consumed         uint64
+	advertised       uint64
+	lastUpdate       uint64
+	sent             uint64
+	sendMax          uint64
+	sendWake         chan struct{}
+	receiveFIN       bool
+	receiveQueuedFIN bool
+	sendFIN          bool
+
+	// fragmenting is accessed only by the stream worker.
+	fragmenting bool
+	writeMu     sync.Mutex
+}
+
+func newStreamState(id uint32, handler streamtype.StreamHandler, flow bool) *streamState {
+	st := &streamState{
+		id:       id,
+		handler:  handler,
+		flow:     flow,
+		queue:    make(chan protocol.Frame, protocol.MaxQueuedStreamFrames),
+		done:     make(chan struct{}),
+		sendWake: make(chan struct{}),
+	}
+	return st
+}
+
+// enqueue accepts a frame only if both the negotiated receive window and the
+// local queue bounds allow it. It never waits for the stream worker.
+func (st *streamState) enqueue(frame protocol.Frame) error {
+	bytes := len(frame.Payload)
+	flowBytes := frame.FlowBytes()
+
+	st.mu.Lock()
+	defer st.mu.Unlock()
+	if st.closed {
+		return errStreamClosed
+	}
+	if st.receiveQueuedFIN {
+		return &streamReceiveError{
+			code:    "protocol_error",
+			message: fmt.Sprintf("stream %d received data after FIN", st.id),
+		}
+	}
+	if st.flow && flowBytes > 0 {
+		if st.received > st.advertised || flowBytes > st.advertised-st.received {
+			return &streamReceiveError{
+				code:    "flow_control_violation",
+				message: fmt.Sprintf("stream %d exceeded receive window", st.id),
+			}
+		}
+	}
+	if st.queuedFrames >= protocol.MaxQueuedStreamFrames ||
+		bytes > protocol.InitialStreamWindow-st.queuedBytes {
+		return &streamReceiveError{
+			code:    "receive_overflow",
+			message: fmt.Sprintf("stream %d receive queue is full", st.id),
+		}
+	}
+
+	st.received += flowBytes
+	if frame.IsFIN() {
+		st.receiveQueuedFIN = true
+	}
+	st.queuedFrames++
+	st.queuedBytes += bytes
+	select {
+	case st.queue <- frame:
+		return nil
+	default:
+		// queuedFrames and the channel capacity use the same limit, so this
+		// is only reachable if an invariant changes. Roll back conservatively.
+		st.received -= flowBytes
+		if frame.IsFIN() {
+			st.receiveQueuedFIN = false
+		}
+		st.queuedFrames--
+		st.queuedBytes -= bytes
+		return &streamReceiveError{code: "receive_overflow", message: "stream receive queue is full"}
+	}
+}
+
+func (st *streamState) dequeued(frame protocol.Frame) {
+	st.mu.Lock()
+	st.queuedFrames--
+	st.queuedBytes -= len(frame.Payload)
+	st.mu.Unlock()
+}
+
+func (st *streamState) isClosed() bool {
+	st.mu.Lock()
+	defer st.mu.Unlock()
+	return st.closed
+}
+
+func (st *streamState) stopNow() bool {
+	st.mu.Lock()
+	if st.closed {
+		st.mu.Unlock()
+		return false
+	}
+	st.closed = true
+	st.mu.Unlock()
+	st.stop.Do(func() { close(st.done) })
+	return true
+}
+
+func (st *streamState) updateSendMax(max uint64) {
+	st.mu.Lock()
+	if !st.closed && max > st.sendMax {
+		st.sendMax = max
+		close(st.sendWake)
+		st.sendWake = make(chan struct{})
+	}
+	st.mu.Unlock()
+}
+
+func (st *streamState) reserveSend(bytes uint64, sessionDone <-chan struct{}) error {
+	if !st.flow || bytes == 0 {
+		st.mu.Lock()
+		closed := st.closed
+		st.mu.Unlock()
+		if closed {
+			return errStreamClosed
+		}
+		return nil
+	}
+
+	for {
+		st.mu.Lock()
+		if st.closed {
+			st.mu.Unlock()
+			return errStreamClosed
+		}
+		if st.sent <= st.sendMax && bytes <= st.sendMax-st.sent {
+			st.sent += bytes
+			st.mu.Unlock()
+			return nil
+		}
+		wake := st.sendWake
+		st.mu.Unlock()
+
+		select {
+		case <-wake:
+		case <-st.done:
+			return errStreamClosed
+		case <-sessionDone:
+			return errors.New("session closed")
+		}
+	}
+}
+
+func (s *Session) sendWindowUpdate(st *streamState, max uint64) error {
+	st.mu.Lock()
+	if st.closed {
+		st.mu.Unlock()
+		return errStreamClosed
+	}
+	if max > st.advertised {
+		st.advertised = max
+	}
+	st.mu.Unlock()
+
+	update := protocol.WindowUpdate{
+		Type:     protocol.ControlWindowUpdate,
+		StreamID: st.id,
+		MaxBytes: max,
+	}
+	payload, _ := json.Marshal(update)
+	return s.sendFrame(0, protocol.FlagSYN, payload)
+}
+
+func (s *Session) consume(st *streamState, bytes uint64) error {
+	if !st.flow || bytes == 0 {
+		return nil
+	}
+
+	var update uint64
+	st.mu.Lock()
+	if !st.closed {
+		st.consumed += bytes
+		if st.consumed-st.lastUpdate >= protocol.StreamWindowUpdateThreshold {
+			st.lastUpdate = st.consumed
+			st.advertised = st.consumed + protocol.InitialStreamWindow
+			update = st.advertised
+		}
+	}
+	st.mu.Unlock()
+	if update != 0 {
+		return s.sendWindowUpdate(st, update)
+	}
+	return nil
+}
+
+func (s *Session) markReceiveClosed(st *streamState) {
+	st.mu.Lock()
+	st.receiveFIN = true
+	complete := st.sendFIN
+	st.mu.Unlock()
+	if complete {
+		s.finishState(st)
+	}
+}
+
+func (s *Session) markSendClosed(st *streamState) {
+	st.mu.Lock()
+	st.sendFIN = true
+	complete := st.receiveFIN
+	st.mu.Unlock()
+	if complete {
+		s.finishState(st)
+	}
+}
+
+func (s *Session) finishState(st *streamState) {
+	s.mu.Lock()
+	if s.streams[st.id] == st {
+		delete(s.streams, st.id)
+	}
+	s.mu.Unlock()
+	st.stopNow()
+}
+
+func (s *Session) failStream(st *streamState, code, message string, notifyPeer bool) {
+	s.mu.Lock()
+	if s.streams[st.id] != st {
+		s.mu.Unlock()
+		return
+	}
+	delete(s.streams, st.id)
+	s.mu.Unlock()
+	if !st.stopNow() {
+		return
+	}
+
+	stream := newStreamCtx(s, st.id)
+	go func() {
+		// Tear down the local sink first so a blocked handler is released even
+		// if the best-effort reset notification cannot be sent promptly.
+		if resetHandler, ok := st.handler.(streamtype.ResetHandler); ok {
+			resetHandler.OnReset(stream, code, message)
+		}
+		// A writer may already have reserved credit when the stream fails.
+		// Wait for that in-flight frame to finish before putting the terminal
+		// reset on the ordered data channel. Writers still waiting for credit
+		// were woken by stopNow and will release this lock without sending.
+		st.writeMu.Lock()
+		defer st.writeMu.Unlock()
+		if notifyPeer {
+			if st.flow {
+				s.sendReset(st.id, code, message)
+			} else {
+				// Legacy peers have no full-stream reset. An empty FIN is the
+				// closest best-effort signal and remains stream-local.
+				_ = s.sendFrame(st.id, protocol.FlagFIN, nil)
+			}
+		}
+	}()
+}
+
+func (s *Session) rejectStream(streamID uint32, code, message string) {
+	s.mu.Lock()
+	flow := s.negotiatedVersion >= 4
+	s.mu.Unlock()
+	go func() {
+		if flow {
+			s.sendReset(streamID, code, message)
+			return
+		}
+		s.sendStreamError(streamID, message)
+	}()
+}
+
+func (s *Session) sendReset(streamID uint32, code, message string) {
+	reset := protocol.StreamReset{
+		Type:     protocol.ControlStreamReset,
+		StreamID: streamID,
+		Code:     code,
+		Message:  message,
+	}
+	payload, _ := json.Marshal(reset)
+	_ = s.sendFrame(0, protocol.FlagSYN, payload)
+}
+
+func (s *Session) applyWindowUpdate(update protocol.WindowUpdate) {
+	if update.StreamID == 0 {
+		return
+	}
+	s.mu.Lock()
+	flow := s.negotiatedVersion >= 4
+	st := s.streams[update.StreamID]
+	s.mu.Unlock()
+	if !flow || st == nil || !st.flow {
+		return
+	}
+	if update.MaxBytes == 0 {
+		s.failStream(st, "invalid_control", "window update must grant a positive maximum", true)
+		return
+	}
+	st.updateSendMax(update.MaxBytes)
+}
+
+func (s *Session) applyStreamReset(reset protocol.StreamReset) {
+	if reset.StreamID == 0 {
+		return
+	}
+	s.mu.Lock()
+	flow := s.negotiatedVersion >= 4
+	st := s.streams[reset.StreamID]
+	s.mu.Unlock()
+	if flow && st != nil && st.flow {
+		s.failStream(st, reset.Code, reset.Message, false)
+	}
+}
+
+func (s *Session) resetMalformedControl(payload []byte, controlErr error) {
+	var target struct {
+		StreamID uint32 `json:"stream_id"`
+	}
+	if json.Unmarshal(payload, &target) != nil || target.StreamID == 0 {
+		return
+	}
+	s.mu.Lock()
+	flow := s.negotiatedVersion >= 4
+	st := s.streams[target.StreamID]
+	s.mu.Unlock()
+	if flow && st != nil && st.flow {
+		s.failStream(st, "invalid_control", controlErr.Error(), true)
+	}
+}
+
+func (s *Session) sendStreamFrame(streamID uint32, flags uint16, payload []byte) error {
+	if err := protocol.ValidateFramePayload(payload); err != nil {
+		return err
+	}
+	s.mu.Lock()
+	st := s.streams[streamID]
+	closed := s.closed
+	s.mu.Unlock()
+	if closed || st == nil {
+		return errStreamClosed
+	}
+
+	st.writeMu.Lock()
+	defer st.writeMu.Unlock()
+	st.mu.Lock()
+	sendFinished := st.sendFIN
+	st.mu.Unlock()
+	if sendFinished {
+		return errStreamFinished
+	}
+	frame := protocol.Frame{StreamID: streamID, Flags: flags, Payload: payload}
+	if err := st.reserveSend(frame.FlowBytes(), s.done); err != nil {
+		return err
+	}
+	if err := s.sendFrame(streamID, flags, payload); err != nil {
+		s.failStream(st, "send_error", err.Error(), false)
+		return err
+	}
+	if frame.IsFIN() {
+		s.markSendClosed(st)
+	}
+	return nil
+}
+
+// Close stops all per-stream workers and releases writers waiting for credit.
+func (s *Session) Close() {
+	s.close.Do(func() {
+		s.mu.Lock()
+		s.closed = true
+		close(s.done)
+		states := make([]*streamState, 0, len(s.streams))
+		for id, st := range s.streams {
+			states = append(states, st)
+			delete(s.streams, id)
+		}
+		s.mu.Unlock()
+
+		for _, st := range states {
+			if !st.stopNow() {
+				continue
+			}
+			if resetHandler, ok := st.handler.(streamtype.ResetHandler); ok {
+				go resetHandler.OnReset(newStreamCtx(s, st.id), "session_closed", "session closed")
+			}
+		}
+	})
+}

--- a/internal/session/flow.go
+++ b/internal/session/flow.go
@@ -69,6 +69,12 @@ func newStreamState(id uint32, handler streamtype.StreamHandler, flow bool) *str
 		done:     make(chan struct{}),
 		sendWake: make(chan struct{}),
 	}
+	if flow {
+		// The v4 SYN opens both directions with the protocol's implicit
+		// initial window; no window_update round trip is required.
+		st.advertised = protocol.InitialStreamWindow
+		st.sendMax = protocol.InitialStreamWindow
+	}
 	return st
 }
 

--- a/internal/session/flow_test.go
+++ b/internal/session/flow_test.go
@@ -3,6 +3,7 @@ package session
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -210,7 +211,7 @@ func TestSlowStreamDoesNotBlockAnotherStream(t *testing.T) {
 	})
 }
 
-func TestV4SenderWaitsForCumulativeCredit(t *testing.T) {
+func TestV4SenderUsesImplicitInitialCreditAndWaitsForUpdate(t *testing.T) {
 	streamReady := make(chan streamtype.Stream, 1)
 	handler := &testHandler{onSYN: func(s streamtype.Stream, _ []byte, _ bool) error {
 		streamReady <- s
@@ -219,23 +220,46 @@ func TestV4SenderWaitsForCumulativeCredit(t *testing.T) {
 	sess, capture := newFlowTestSession(t, 4, handler)
 	openTestStream(sess, 1, false)
 	stream := <-streamReady
-	waitFor(t, func() bool { return len(capture.controls(protocol.ControlWindowUpdate)) == 1 })
+	if updates := capture.controls(protocol.ControlWindowUpdate); len(updates) != 0 {
+		t.Fatalf("v4 SYN sent redundant initial window update: %#v", updates)
+	}
+
+	payload := make([]byte, protocol.MaxChunkSize)
+	frames := protocol.InitialStreamWindow / protocol.MaxChunkSize
+	fillDone := make(chan error, 1)
+	go func() {
+		for i := 0; i < frames; i++ {
+			if err := stream.WriteDAT(payload); err != nil {
+				fillDone <- fmt.Errorf("write implicit window frame %d: %w", i, err)
+				return
+			}
+		}
+		fillDone <- nil
+	}()
+	select {
+	case err := <-fillDone:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("implicit initial window did not become sendable")
+	}
 
 	writeDone := make(chan error, 1)
 	go func() { writeDone <- stream.WriteDAT([]byte("x")) }()
 	select {
 	case err := <-writeDone:
-		t.Fatalf("write completed before credit: %v", err)
+		t.Fatalf("write beyond implicit window completed early: %v", err)
 	case <-time.After(30 * time.Millisecond):
 	}
-	if got := capture.countData(1); got != 0 {
-		t.Fatalf("sent %d data frames before credit, want 0", got)
+	if got := capture.countData(1); got != frames {
+		t.Fatalf("sent %d data frames before update, want %d", got, frames)
 	}
 
 	sendControl(sess, protocol.WindowUpdate{
 		Type:     protocol.ControlWindowUpdate,
 		StreamID: 1,
-		MaxBytes: 1,
+		MaxBytes: protocol.InitialStreamWindow + 1,
 	})
 	select {
 	case err := <-writeDone:
@@ -245,8 +269,8 @@ func TestV4SenderWaitsForCumulativeCredit(t *testing.T) {
 	case <-time.After(time.Second):
 		t.Fatal("write did not resume after credit")
 	}
-	if got := capture.countData(1); got != 1 {
-		t.Fatalf("sent %d data frames after credit, want 1", got)
+	if got := capture.countData(1); got != frames+1 {
+		t.Fatalf("sent %d data frames after update, want %d", got, frames+1)
 	}
 }
 
@@ -256,13 +280,9 @@ func TestStreamResetFollowsAlreadyReservedData(t *testing.T) {
 		streamReady <- s
 		return nil
 	}}
-	sess, capture := newFlowTestSession(t, 4, handler)
+	sess, _ := newFlowTestSession(t, 4, handler)
 	openTestStream(sess, 1, false)
 	stream := <-streamReady
-	waitFor(t, func() bool { return len(capture.controls(protocol.ControlWindowUpdate)) == 1 })
-	sendControl(sess, protocol.WindowUpdate{
-		Type: protocol.ControlWindowUpdate, StreamID: 1, MaxBytes: 1,
-	})
 
 	sess.mu.Lock()
 	st := sess.streams[1]
@@ -380,7 +400,9 @@ func TestV4ReceiveWindowViolationResetsOnlyOffendingStream(t *testing.T) {
 	sess, capture := newFlowTestSession(t, 4, handler)
 	openTestStream(sess, 1, false)
 	openTestStream(sess, 3, false)
-	waitFor(t, func() bool { return len(capture.controls(protocol.ControlWindowUpdate)) == 2 })
+	if updates := capture.controls(protocol.ControlWindowUpdate); len(updates) != 0 {
+		t.Fatalf("v4 SYNs sent redundant initial window updates: %#v", updates)
+	}
 
 	payload := make([]byte, protocol.MaxChunkSize)
 	sess.HandleMessage(protocol.BuildFrame(1, protocol.FlagDAT, payload))
@@ -404,9 +426,10 @@ func TestV4ReceiveWindowViolationResetsOnlyOffendingStream(t *testing.T) {
 	}
 }
 
-func TestV4ReceiverGrantsNoDataBeforeSYNIsRouted(t *testing.T) {
+func TestV4ReceiverQueuesImplicitWindowDataBehindSYN(t *testing.T) {
 	synStarted := make(chan struct{})
 	releaseSYN := make(chan struct{})
+	dataDelivered := make(chan struct{})
 	var startOnce, releaseOnce sync.Once
 	handler := &testHandler{
 		onSYN: func(streamtype.Stream, []byte, bool) error {
@@ -417,6 +440,10 @@ func TestV4ReceiverGrantsNoDataBeforeSYNIsRouted(t *testing.T) {
 		onReset: func(streamtype.Stream, string, string) {
 			releaseOnce.Do(func() { close(releaseSYN) })
 		},
+		onDAT: func(streamtype.Stream, []byte) error {
+			close(dataDelivered)
+			return nil
+		},
 	}
 	sess, capture := newFlowTestSession(t, 4, handler)
 	openTestStream(sess, 1, false)
@@ -426,12 +453,25 @@ func TestV4ReceiverGrantsNoDataBeforeSYNIsRouted(t *testing.T) {
 		t.Fatal("SYN handler did not start")
 	}
 
-	// A v4 sender starts at zero credit. Data sent before the listener has
-	// routed SYN and advertised its first window is a stream-local violation.
+	// The initial window is implicit, so ordered DAT can queue while OnSYN is
+	// still running. The worker must not deliver it ahead of SYN.
 	sess.HandleMessage(protocol.BuildFrame(1, protocol.FlagDAT, []byte{1}))
-	waitFor(t, func() bool { return len(capture.controls(protocol.ControlStreamReset)) == 1 })
+	select {
+	case <-dataDelivered:
+		t.Fatal("DAT overtook the blocked SYN handler")
+	case <-time.After(30 * time.Millisecond):
+	}
+	if resets := capture.controls(protocol.ControlStreamReset); len(resets) != 0 {
+		t.Fatalf("implicit-window DAT reset the stream: %#v", resets)
+	}
 	if updates := capture.controls(protocol.ControlWindowUpdate); len(updates) != 0 {
-		t.Fatalf("sent %d window updates before SYN routing completed", len(updates))
+		t.Fatalf("v4 SYN sent redundant initial window update: %#v", updates)
+	}
+	releaseOnce.Do(func() { close(releaseSYN) })
+	select {
+	case <-dataDelivered:
+	case <-time.After(time.Second):
+		t.Fatal("queued DAT was not delivered after SYN completed")
 	}
 }
 
@@ -443,16 +483,18 @@ func TestConsumedBytesReplenishWindow(t *testing.T) {
 	}}
 	sess, capture := newFlowTestSession(t, 4, handler)
 	openTestStream(sess, 1, false)
-	waitFor(t, func() bool { return len(capture.controls(protocol.ControlWindowUpdate)) == 1 })
+	if updates := capture.controls(protocol.ControlWindowUpdate); len(updates) != 0 {
+		t.Fatalf("v4 SYN sent redundant initial window update: %#v", updates)
+	}
 
 	payload := make([]byte, protocol.MaxChunkSize)
 	for i := 0; i < protocol.StreamWindowUpdateThreshold/protocol.MaxChunkSize; i++ {
 		sess.HandleMessage(protocol.BuildFrame(1, protocol.FlagDAT, payload))
 	}
-	waitFor(t, func() bool { return len(capture.controls(protocol.ControlWindowUpdate)) == 2 })
+	waitFor(t, func() bool { return len(capture.controls(protocol.ControlWindowUpdate)) == 1 })
 	updates := capture.controls(protocol.ControlWindowUpdate)
 	want := float64(protocol.InitialStreamWindow + protocol.StreamWindowUpdateThreshold)
-	if got := updates[1]["max_bytes"]; got != want {
+	if got := updates[0]["max_bytes"]; got != want {
 		t.Fatalf("replenished max_bytes = %v, want %.0f", got, want)
 	}
 	if got := consumed.Load(); got != protocol.StreamWindowUpdateThreshold {
@@ -486,6 +528,12 @@ func TestResetAndSessionCloseWakeBlockedWriters(t *testing.T) {
 			sess, _ := newFlowTestSession(t, 4, handler)
 			openTestStream(sess, 1, false)
 			stream := <-streamReady
+			sess.mu.Lock()
+			st := sess.streams[1]
+			sess.mu.Unlock()
+			if err := st.reserveSend(protocol.InitialStreamWindow, sess.done); err != nil {
+				t.Fatalf("reserve implicit initial window: %v", err)
+			}
 			writeDone := make(chan error, 1)
 			go func() { writeDone <- stream.WriteDAT([]byte("blocked")) }()
 			select {

--- a/internal/session/flow_test.go
+++ b/internal/session/flow_test.go
@@ -1,0 +1,508 @@
+package session
+
+import (
+	"encoding/json"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/richlegrand/bitbang/internal/auth"
+	"github.com/richlegrand/bitbang/internal/protocol"
+	"github.com/richlegrand/bitbang/internal/streamtype"
+)
+
+type frameCapture struct {
+	mu     sync.Mutex
+	frames []protocol.Frame
+}
+
+func (c *frameCapture) send(streamID uint32, flags uint16, payload []byte) error {
+	c.mu.Lock()
+	c.frames = append(c.frames, protocol.Frame{
+		StreamID: streamID,
+		Flags:    flags,
+		Payload:  append([]byte(nil), payload...),
+	})
+	c.mu.Unlock()
+	return nil
+}
+
+func (c *frameCapture) countData(streamID uint32) int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	count := 0
+	for _, frame := range c.frames {
+		if frame.StreamID == streamID && !frame.IsSYN() && len(frame.Payload) > 0 {
+			count++
+		}
+	}
+	return count
+}
+
+func (c *frameCapture) controls(controlType string) []map[string]interface{} {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	var controls []map[string]interface{}
+	for _, frame := range c.frames {
+		if frame.StreamID != 0 || !frame.IsSYN() {
+			continue
+		}
+		var control map[string]interface{}
+		if json.Unmarshal(frame.Payload, &control) == nil && control["type"] == controlType {
+			controls = append(controls, control)
+		}
+	}
+	return controls
+}
+
+type testHandler struct {
+	onSYN   func(streamtype.Stream, []byte, bool) error
+	onDAT   func(streamtype.Stream, []byte) error
+	onFIN   func(streamtype.Stream, []byte) error
+	onReset func(streamtype.Stream, string, string)
+}
+
+func (h *testHandler) Type() string           { return "test" }
+func (h *testHandler) OnConnect(string) error { return nil }
+func (h *testHandler) OnSYN(s streamtype.Stream, p []byte, final bool) error {
+	if h.onSYN != nil {
+		return h.onSYN(s, p, final)
+	}
+	return nil
+}
+func (h *testHandler) OnDAT(s streamtype.Stream, p []byte) error {
+	if h.onDAT != nil {
+		return h.onDAT(s, p)
+	}
+	return nil
+}
+func (h *testHandler) OnFIN(s streamtype.Stream, p []byte) error {
+	if h.onFIN != nil {
+		return h.onFIN(s, p)
+	}
+	return nil
+}
+func (h *testHandler) OnReset(s streamtype.Stream, code, message string) {
+	if h.onReset != nil {
+		h.onReset(s, code, message)
+	}
+}
+
+func newFlowTestSession(t *testing.T, version int, handler streamtype.StreamHandler) (*Session, *frameCapture) {
+	t.Helper()
+	capture := &frameCapture{}
+	sess := New(nil, auth.New(""), false, handler)
+	sess.sendFrame = capture.send
+	t.Cleanup(sess.Close)
+	connect, _ := json.Marshal(map[string]interface{}{
+		"type":    "connect",
+		"path":    "/",
+		"version": version,
+	})
+	sess.HandleMessage(protocol.BuildFrame(0, protocol.FlagSYN, connect))
+	return sess, capture
+}
+
+func openTestStream(sess *Session, id uint32, final bool) {
+	flags := uint16(protocol.FlagSYN)
+	if final {
+		flags |= protocol.FlagFIN
+	}
+	sess.HandleMessage(protocol.BuildFrame(id, flags, []byte(`{"type":"test"}`)))
+}
+
+func sendControl(sess *Session, control interface{}) {
+	payload, _ := json.Marshal(control)
+	sess.HandleMessage(protocol.BuildFrame(0, protocol.FlagSYN, payload))
+}
+
+func TestNegotiatedVersionLockedByFirstConnect(t *testing.T) {
+	tests := []struct {
+		name    string
+		version int
+		want    int
+	}{
+		{name: "missing defaults to v2", want: 2},
+		{name: "v3", version: 3, want: 3},
+		{name: "v4", version: 4, want: 4},
+		{name: "future version", version: 99, want: protocol.SWSPVersion},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sess, capture := newFlowTestSession(t, tt.version, &testHandler{})
+			sess.mu.Lock()
+			got := sess.negotiatedVersion
+			sess.mu.Unlock()
+			if got != tt.want {
+				t.Fatalf("negotiated version = %d, want %d", got, tt.want)
+			}
+			ready := capture.controls("ready")
+			if len(ready) != 1 || int(ready[0]["negotiated_version"].(float64)) != tt.want {
+				t.Fatalf("ready controls = %#v, want negotiated_version %d", ready, tt.want)
+			}
+
+			// A navigation connect may update routing, but not wire semantics.
+			sess.handleConnect("/new-path", 2)
+			sess.mu.Lock()
+			got = sess.negotiatedVersion
+			sess.mu.Unlock()
+			if got != tt.want {
+				t.Fatalf("renegotiated version = %d, want locked %d", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSlowStreamDoesNotBlockAnotherStream(t *testing.T) {
+	slowStarted := make(chan struct{})
+	fastDelivered := make(chan struct{})
+	releaseSlow := make(chan struct{})
+	var startOnce, fastOnce, releaseOnce sync.Once
+	handler := &testHandler{
+		onDAT: func(s streamtype.Stream, _ []byte) error {
+			switch s.ID() {
+			case 1:
+				startOnce.Do(func() { close(slowStarted) })
+				<-releaseSlow
+			case 3:
+				fastOnce.Do(func() { close(fastDelivered) })
+			}
+			return nil
+		},
+		onReset: func(s streamtype.Stream, _, _ string) {
+			if s.ID() == 1 {
+				releaseOnce.Do(func() { close(releaseSlow) })
+			}
+		},
+	}
+	sess, _ := newFlowTestSession(t, 3, handler)
+	openTestStream(sess, 1, false)
+	openTestStream(sess, 3, false)
+
+	sess.HandleMessage(protocol.BuildFrame(1, protocol.FlagDAT, []byte("block")))
+	select {
+	case <-slowStarted:
+	case <-time.After(time.Second):
+		t.Fatal("slow stream handler did not start")
+	}
+	sess.HandleMessage(protocol.BuildFrame(3, protocol.FlagDAT, []byte("fast")))
+	select {
+	case <-fastDelivered:
+	case <-time.After(time.Second):
+		t.Fatal("healthy stream was blocked by slow stream")
+	}
+
+	// Saturating the slow stream's frame bound resets only that stream and
+	// must not make HandleMessage wait for its blocked handler.
+	started := time.Now()
+	for i := 0; i <= protocol.MaxQueuedStreamFrames; i++ {
+		sess.HandleMessage(protocol.BuildFrame(1, protocol.FlagDAT, nil))
+	}
+	if elapsed := time.Since(started); elapsed > 250*time.Millisecond {
+		t.Fatalf("queue saturation blocked HandleMessage for %v", elapsed)
+	}
+	waitFor(t, func() bool {
+		sess.mu.Lock()
+		defer sess.mu.Unlock()
+		return sess.streams[1] == nil && sess.streams[3] != nil
+	})
+}
+
+func TestV4SenderWaitsForCumulativeCredit(t *testing.T) {
+	streamReady := make(chan streamtype.Stream, 1)
+	handler := &testHandler{onSYN: func(s streamtype.Stream, _ []byte, _ bool) error {
+		streamReady <- s
+		return nil
+	}}
+	sess, capture := newFlowTestSession(t, 4, handler)
+	openTestStream(sess, 1, false)
+	stream := <-streamReady
+	waitFor(t, func() bool { return len(capture.controls(protocol.ControlWindowUpdate)) == 1 })
+
+	writeDone := make(chan error, 1)
+	go func() { writeDone <- stream.WriteDAT([]byte("x")) }()
+	select {
+	case err := <-writeDone:
+		t.Fatalf("write completed before credit: %v", err)
+	case <-time.After(30 * time.Millisecond):
+	}
+	if got := capture.countData(1); got != 0 {
+		t.Fatalf("sent %d data frames before credit, want 0", got)
+	}
+
+	sendControl(sess, protocol.WindowUpdate{
+		Type:     protocol.ControlWindowUpdate,
+		StreamID: 1,
+		MaxBytes: 1,
+	})
+	select {
+	case err := <-writeDone:
+		if err != nil {
+			t.Fatalf("credited write: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("write did not resume after credit")
+	}
+	if got := capture.countData(1); got != 1 {
+		t.Fatalf("sent %d data frames after credit, want 1", got)
+	}
+}
+
+func TestStreamResetFollowsAlreadyReservedData(t *testing.T) {
+	streamReady := make(chan streamtype.Stream, 1)
+	handler := &testHandler{onSYN: func(s streamtype.Stream, _ []byte, _ bool) error {
+		streamReady <- s
+		return nil
+	}}
+	sess, capture := newFlowTestSession(t, 4, handler)
+	openTestStream(sess, 1, false)
+	stream := <-streamReady
+	waitFor(t, func() bool { return len(capture.controls(protocol.ControlWindowUpdate)) == 1 })
+	sendControl(sess, protocol.WindowUpdate{
+		Type: protocol.ControlWindowUpdate, StreamID: 1, MaxBytes: 1,
+	})
+
+	sess.mu.Lock()
+	st := sess.streams[1]
+	sess.mu.Unlock()
+	dataStarted := make(chan struct{})
+	releaseData := make(chan struct{})
+	events := make(chan string, 2)
+	sess.sendFrame = func(streamID uint32, _ uint16, _ []byte) error {
+		if streamID == 1 {
+			close(dataStarted)
+			<-releaseData
+			events <- "data"
+			return nil
+		}
+		events <- "reset"
+		return nil
+	}
+
+	writeDone := make(chan error, 1)
+	go func() { writeDone <- stream.WriteDAT([]byte("x")) }()
+	select {
+	case <-dataStarted:
+	case <-time.After(time.Second):
+		t.Fatal("data send did not start")
+	}
+	sess.failStream(st, "test_reset", "reset", true)
+	select {
+	case event := <-events:
+		t.Fatalf("terminal event %q overtook blocked data", event)
+	case <-time.After(20 * time.Millisecond):
+	}
+
+	close(releaseData)
+	select {
+	case err := <-writeDone:
+		if err != nil {
+			t.Fatalf("in-flight data send: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for data send")
+	}
+	for _, want := range []string{"data", "reset"} {
+		select {
+		case got := <-events:
+			if got != want {
+				t.Fatalf("send order = %q before %q", got, want)
+			}
+		case <-time.After(time.Second):
+			t.Fatalf("timed out waiting for %s send", want)
+		}
+	}
+}
+
+func TestV3DataPathDoesNotWaitForOrSendCredit(t *testing.T) {
+	received := make(chan string, 1)
+	handler := &testHandler{
+		onSYN: func(s streamtype.Stream, _ []byte, _ bool) error {
+			return s.WriteDAT([]byte("response"))
+		},
+		onDAT: func(_ streamtype.Stream, payload []byte) error {
+			received <- string(payload)
+			return nil
+		},
+	}
+	sess, capture := newFlowTestSession(t, 3, handler)
+	openTestStream(sess, 1, false)
+	waitFor(t, func() bool { return capture.countData(1) == 1 })
+	if controls := capture.controls(protocol.ControlWindowUpdate); len(controls) != 0 {
+		t.Fatalf("v3 session sent window controls: %#v", controls)
+	}
+
+	sess.HandleMessage(protocol.BuildFrame(1, protocol.FlagDAT, []byte("request")))
+	select {
+	case got := <-received:
+		if got != "request" {
+			t.Fatalf("v3 inbound payload = %q, want request", got)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("v3 inbound data waited for flow-control credit")
+	}
+}
+
+func TestV4OversizedWriteFailsBeforeWaitingForCredit(t *testing.T) {
+	streamReady := make(chan streamtype.Stream, 1)
+	handler := &testHandler{onSYN: func(s streamtype.Stream, _ []byte, _ bool) error {
+		streamReady <- s
+		return nil
+	}}
+	sess, _ := newFlowTestSession(t, 4, handler)
+	openTestStream(sess, 1, false)
+	stream := <-streamReady
+	if err := stream.WriteDAT(make([]byte, protocol.MaxChunkSize+1)); err == nil {
+		t.Fatal("oversized v4 write did not fail")
+	}
+}
+
+func TestV4ReceiveWindowViolationResetsOnlyOffendingStream(t *testing.T) {
+	slowStarted := make(chan struct{})
+	releaseSlow := make(chan struct{})
+	var startOnce, releaseOnce sync.Once
+	handler := &testHandler{
+		onDAT: func(s streamtype.Stream, _ []byte) error {
+			if s.ID() == 1 {
+				startOnce.Do(func() { close(slowStarted) })
+				<-releaseSlow
+			}
+			return nil
+		},
+		onReset: func(s streamtype.Stream, _, _ string) {
+			if s.ID() == 1 {
+				releaseOnce.Do(func() { close(releaseSlow) })
+			}
+		},
+	}
+	sess, capture := newFlowTestSession(t, 4, handler)
+	openTestStream(sess, 1, false)
+	openTestStream(sess, 3, false)
+	waitFor(t, func() bool { return len(capture.controls(protocol.ControlWindowUpdate)) == 2 })
+
+	payload := make([]byte, protocol.MaxChunkSize)
+	sess.HandleMessage(protocol.BuildFrame(1, protocol.FlagDAT, payload))
+	select {
+	case <-slowStarted:
+	case <-time.After(time.Second):
+		t.Fatal("slow handler did not start")
+	}
+	for i := 1; i < protocol.InitialStreamWindow/protocol.MaxChunkSize; i++ {
+		sess.HandleMessage(protocol.BuildFrame(1, protocol.FlagDAT, payload))
+	}
+	// The next byte exceeds the exact cumulative grant.
+	sess.HandleMessage(protocol.BuildFrame(1, protocol.FlagDAT, []byte{1}))
+
+	waitFor(t, func() bool { return len(capture.controls(protocol.ControlStreamReset)) == 1 })
+	sess.mu.Lock()
+	offending, healthy := sess.streams[1], sess.streams[3]
+	sess.mu.Unlock()
+	if offending != nil || healthy == nil {
+		t.Fatalf("stream states after violation: offending=%v healthy=%v", offending != nil, healthy != nil)
+	}
+}
+
+func TestV4ReceiverGrantsNoDataBeforeSYNIsRouted(t *testing.T) {
+	synStarted := make(chan struct{})
+	releaseSYN := make(chan struct{})
+	var startOnce, releaseOnce sync.Once
+	handler := &testHandler{
+		onSYN: func(streamtype.Stream, []byte, bool) error {
+			startOnce.Do(func() { close(synStarted) })
+			<-releaseSYN
+			return nil
+		},
+		onReset: func(streamtype.Stream, string, string) {
+			releaseOnce.Do(func() { close(releaseSYN) })
+		},
+	}
+	sess, capture := newFlowTestSession(t, 4, handler)
+	openTestStream(sess, 1, false)
+	select {
+	case <-synStarted:
+	case <-time.After(time.Second):
+		t.Fatal("SYN handler did not start")
+	}
+
+	// A v4 sender starts at zero credit. Data sent before the listener has
+	// routed SYN and advertised its first window is a stream-local violation.
+	sess.HandleMessage(protocol.BuildFrame(1, protocol.FlagDAT, []byte{1}))
+	waitFor(t, func() bool { return len(capture.controls(protocol.ControlStreamReset)) == 1 })
+	if updates := capture.controls(protocol.ControlWindowUpdate); len(updates) != 0 {
+		t.Fatalf("sent %d window updates before SYN routing completed", len(updates))
+	}
+}
+
+func TestConsumedBytesReplenishWindow(t *testing.T) {
+	var consumed atomic.Int64
+	handler := &testHandler{onDAT: func(streamtype.Stream, []byte) error {
+		consumed.Add(protocol.MaxChunkSize)
+		return nil
+	}}
+	sess, capture := newFlowTestSession(t, 4, handler)
+	openTestStream(sess, 1, false)
+	waitFor(t, func() bool { return len(capture.controls(protocol.ControlWindowUpdate)) == 1 })
+
+	payload := make([]byte, protocol.MaxChunkSize)
+	for i := 0; i < protocol.StreamWindowUpdateThreshold/protocol.MaxChunkSize; i++ {
+		sess.HandleMessage(protocol.BuildFrame(1, protocol.FlagDAT, payload))
+	}
+	waitFor(t, func() bool { return len(capture.controls(protocol.ControlWindowUpdate)) == 2 })
+	updates := capture.controls(protocol.ControlWindowUpdate)
+	want := float64(protocol.InitialStreamWindow + protocol.StreamWindowUpdateThreshold)
+	if got := updates[1]["max_bytes"]; got != want {
+		t.Fatalf("replenished max_bytes = %v, want %.0f", got, want)
+	}
+	if got := consumed.Load(); got != protocol.StreamWindowUpdateThreshold {
+		t.Fatalf("consumed bytes = %d, want %d", got, protocol.StreamWindowUpdateThreshold)
+	}
+}
+
+func TestResetAndSessionCloseWakeBlockedWriters(t *testing.T) {
+	for _, tt := range []struct {
+		name  string
+		close func(*Session)
+	}{
+		{
+			name: "stream reset",
+			close: func(sess *Session) {
+				sendControl(sess, protocol.StreamReset{
+					Type:     protocol.ControlStreamReset,
+					StreamID: 1,
+					Code:     "cancelled",
+				})
+			},
+		},
+		{name: "session close", close: func(sess *Session) { sess.Close() }},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			streamReady := make(chan streamtype.Stream, 1)
+			handler := &testHandler{onSYN: func(s streamtype.Stream, _ []byte, _ bool) error {
+				streamReady <- s
+				return nil
+			}}
+			sess, _ := newFlowTestSession(t, 4, handler)
+			openTestStream(sess, 1, false)
+			stream := <-streamReady
+			writeDone := make(chan error, 1)
+			go func() { writeDone <- stream.WriteDAT([]byte("blocked")) }()
+			select {
+			case <-writeDone:
+				t.Fatal("write completed before reset")
+			case <-time.After(30 * time.Millisecond):
+			}
+
+			tt.close(sess)
+			select {
+			case err := <-writeDone:
+				if !errors.Is(err, errStreamClosed) && err.Error() != "session closed" {
+					t.Fatalf("blocked write error = %v", err)
+				}
+			case <-time.After(time.Second):
+				t.Fatal("blocked write did not wake")
+			}
+		})
+	}
+}

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -221,11 +221,6 @@ func (s *Session) processStreamFrame(st *streamState, stream *streamCtx, frame p
 		if err := st.handler.OnSYN(stream, frame.Payload, frame.IsFIN()); err != nil {
 			return err
 		}
-		if st.flow {
-			if err := s.sendWindowUpdate(st, protocol.InitialStreamWindow); err != nil {
-				return fmt.Errorf("send initial window: %w", err)
-			}
-		}
 		if frame.IsFIN() {
 			s.markReceiveClosed(st)
 		}

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -42,21 +42,21 @@ type Session struct {
 	connectPath   string
 	authenticated bool
 	ready         bool
+	// negotiatedVersion is fixed by the first accepted connect message.
+	// Later connect messages may update the path, but cannot change the
+	// transport semantics of an established data channel.
+	negotiatedVersion int
 	// authFails counts wrong PIN attempts on this session. After
 	// maxAuthFails the data channel is closed, forcing a fresh WebRTC
 	// handshake to make further guesses (rate-limits brute-force).
 	authFails int
 
-	// Per-stream routing: once a SYN dispatches a stream to a handler,
-	// subsequent DAT/FIN frames on that stream go to the same handler.
-	streamHandler map[uint32]streamtype.StreamHandler
-
-	// reasm buffers WebSocket message fragments per stream. A large WS
-	// message arrives as DAT frames with FLAG_MORE on every non-final chunk;
-	// we reassemble before delivering to OnDAT so the message boundary is
-	// preserved. Only WS streams set FLAG_MORE, so byte-stream handlers
-	// (http/file/shell) never populate this.
-	reasm map[uint32][]byte
+	// streams owns the independently queued and flow-controlled state for
+	// every application stream. HandleMessage never waits for a worker.
+	streams map[uint32]*streamState
+	closed  bool
+	done    chan struct{}
+	close   sync.Once
 
 	// video, if set, negotiates a secondary video PeerConnection with the
 	// browser over stream-0 control frames (relayed to an external media
@@ -79,12 +79,12 @@ type Session struct {
 // Each handler's Type() must be unique within the session.
 func New(dc *webrtc.DataChannel, pin *auth.PINAuth, verbose bool, handlers ...streamtype.StreamHandler) *Session {
 	s := &Session{
-		DC:            dc,
-		PIN:           pin,
-		Verbose:       verbose,
-		handlers:      make(map[string]streamtype.StreamHandler, len(handlers)),
-		streamHandler: make(map[uint32]streamtype.StreamHandler),
-		reasm:         make(map[uint32][]byte),
+		DC:       dc,
+		PIN:      pin,
+		Verbose:  verbose,
+		handlers: make(map[string]streamtype.StreamHandler, len(handlers)),
+		streams:  make(map[uint32]*streamState),
+		done:     make(chan struct{}),
 	}
 	s.sendFrame = s.dcSend
 	for _, h := range handlers {
@@ -97,7 +97,10 @@ func New(dc *webrtc.DataChannel, pin *auth.PINAuth, verbose bool, handlers ...st
 // underlying data channel if it's open, otherwise reports an error.
 // Tests override Session.sendFrame; production never does.
 func (s *Session) dcSend(streamID uint32, flags uint16, payload []byte) error {
-	if s.DC.ReadyState() != webrtc.DataChannelStateOpen {
+	if err := protocol.ValidateFramePayload(payload); err != nil {
+		return err
+	}
+	if s.DC == nil || s.DC.ReadyState() != webrtc.DataChannelStateOpen {
 		return fmt.Errorf("data channel closed")
 	}
 	return s.DC.Send(protocol.BuildFrame(streamID, flags, payload))
@@ -106,6 +109,12 @@ func (s *Session) dcSend(streamID uint32, flags uint16, payload []byte) error {
 // HandleMessage parses a SWSP frame and routes it. Wire this to
 // dc.OnMessage at peer setup time.
 func (s *Session) HandleMessage(data []byte) {
+	s.mu.Lock()
+	closed := s.closed
+	s.mu.Unlock()
+	if closed {
+		return
+	}
 	frame, err := protocol.ParseFrame(data)
 	if err != nil {
 		log.Printf("Failed to parse frame: %v", err)
@@ -117,14 +126,10 @@ func (s *Session) HandleMessage(data []byte) {
 		return
 	}
 
-	if frame.IsSYN() {
-		s.handleSYN(frame)
-	} else {
-		s.handleBody(frame)
-	}
+	s.handleStreamFrame(frame)
 }
 
-func (s *Session) handleSYN(frame protocol.Frame) {
+func (s *Session) handleStreamFrame(frame protocol.Frame) {
 	// SECURITY: gate every non-stream-0 SYN on a completed handshake.
 	// Without this check, an attacker who has the WebRTC channel up
 	// (post bidirectional-verify) but has not sent `connect` / `auth`
@@ -132,10 +137,26 @@ func (s *Session) handleSYN(frame protocol.Frame) {
 	// by jacopotediosi against OctoPrint-BitBang 0.2.7, PR #1443.
 	s.mu.Lock()
 	ready := s.ready
+	st := s.streams[frame.StreamID]
 	s.mu.Unlock()
 	if !ready {
-		log.Printf("Rejecting SYN on stream %d: session not ready (auth bypass attempt?)", frame.StreamID)
-		s.sendStreamError(frame.StreamID, "unauthenticated")
+		if frame.IsSYN() {
+			log.Printf("Rejecting SYN on stream %d: session not ready (auth bypass attempt?)", frame.StreamID)
+			s.rejectStream(frame.StreamID, "unauthenticated", "session is not ready")
+		}
+		return
+	}
+	if !frame.IsSYN() {
+		if st == nil {
+			return
+		}
+		if err := st.enqueue(frame); err != nil {
+			s.failStream(st, receiveErrorCode(err), err.Error(), true)
+		}
+		return
+	}
+	if st != nil {
+		s.failStream(st, "duplicate_syn", "duplicate SYN", true)
 		return
 	}
 
@@ -152,74 +173,97 @@ func (s *Session) handleSYN(frame protocol.Frame) {
 	handler, ok := s.handlers[peek.Type]
 	if !ok {
 		log.Printf("No handler for stream type %q (stream %d)", peek.Type, frame.StreamID)
-		s.sendStreamError(frame.StreamID, fmt.Sprintf("unsupported stream type: %s", peek.Type))
+		s.rejectStream(frame.StreamID, "unsupported_stream", fmt.Sprintf("unsupported stream type: %s", peek.Type))
 		return
 	}
 
 	s.mu.Lock()
-	s.streamHandler[frame.StreamID] = handler
-	s.mu.Unlock()
-
-	stream := newStreamCtx(s, frame.StreamID)
-	if err := handler.OnSYN(stream, frame.Payload, frame.IsFIN()); err != nil {
-		log.Printf("Handler OnSYN error (stream %d, type %q): %v", frame.StreamID, peek.Type, err)
-	}
-	if frame.IsFIN() {
-		// SYN|FIN: stream is complete in one frame. Clean up the routing
-		// table; handler's OnSYN already handled the final state.
-		s.mu.Lock()
-		delete(s.streamHandler, frame.StreamID)
+	if s.closed || s.streams[frame.StreamID] != nil {
 		s.mu.Unlock()
+		return
+	}
+	st = newStreamState(frame.StreamID, handler, s.negotiatedVersion >= 4)
+	s.streams[frame.StreamID] = st
+	s.mu.Unlock()
+	if err := st.enqueue(frame); err != nil {
+		s.failStream(st, receiveErrorCode(err), err.Error(), true)
+		return
+	}
+	go s.runStream(st)
+}
+
+func (s *Session) runStream(st *streamState) {
+	stream := newStreamCtx(s, st.id)
+	for {
+		select {
+		case <-s.done:
+			return
+		case <-st.done:
+			return
+		case frame := <-st.queue:
+			if st.isClosed() {
+				st.dequeued(frame)
+				return
+			}
+			err := s.processStreamFrame(st, stream, frame)
+			st.dequeued(frame)
+			if err != nil {
+				log.Printf("Handler error (stream %d, type %q): %v", st.id, st.handler.Type(), err)
+				s.failStream(st, "handler_error", err.Error(), true)
+				return
+			}
+		}
 	}
 }
 
-func (s *Session) handleBody(frame protocol.Frame) {
-	// SECURITY: same gate as handleSYN. The handler-nil short-circuit
-	// below already catches the common bypass shape (no SYN was ever
-	// dispatched, so streamHandler[id] is nil), but checking ready
-	// explicitly is belt-and-suspenders — and gives the right log
-	// signal if something tries it.
-	s.mu.Lock()
-	ready := s.ready
-	handler := s.streamHandler[frame.StreamID]
-	s.mu.Unlock()
-	if !ready || handler == nil {
-		return
-	}
-
-	stream := newStreamCtx(s, frame.StreamID)
-	if frame.IsFIN() {
-		if err := handler.OnFIN(stream, frame.Payload); err != nil {
-			log.Printf("Handler OnFIN error (stream %d): %v", frame.StreamID, err)
+func (s *Session) processStreamFrame(st *streamState, stream *streamCtx, frame protocol.Frame) error {
+	if frame.IsSYN() {
+		if err := st.handler.OnSYN(stream, frame.Payload, frame.IsFIN()); err != nil {
+			return err
 		}
-		s.mu.Lock()
-		delete(s.streamHandler, frame.StreamID)
-		delete(s.reasm, frame.StreamID)
-		s.mu.Unlock()
-		return
+		if st.flow {
+			if err := s.sendWindowUpdate(st, protocol.InitialStreamWindow); err != nil {
+				return fmt.Errorf("send initial window: %w", err)
+			}
+		}
+		if frame.IsFIN() {
+			s.markReceiveClosed(st)
+		}
+		return nil
 	}
 
-	// Reassemble a chunked WebSocket message: FLAG_MORE marks non-final
-	// fragments. Buffer until the final chunk, then deliver the whole message.
-	// Only WS streams set FLAG_MORE, so byte-stream handlers (http/file/shell)
-	// see each DAT delivered as-is.
-	payload := frame.Payload
-	if frame.IsMORE() {
-		s.mu.Lock()
-		s.reasm[frame.StreamID] = append(s.reasm[frame.StreamID], payload...)
-		s.mu.Unlock()
-		return
+	if frame.IsFIN() {
+		if frame.IsMORE() || st.fragmenting {
+			return fmt.Errorf("FIN during fragmented message")
+		}
+		if err := st.handler.OnFIN(stream, frame.Payload); err != nil {
+			return err
+		}
+		if err := s.consume(st, frame.FlowBytes()); err != nil {
+			return fmt.Errorf("replenish receive window: %w", err)
+		}
+		s.markReceiveClosed(st)
+		return nil
 	}
-	s.mu.Lock()
-	if buf, ok := s.reasm[frame.StreamID]; ok {
-		delete(s.reasm, frame.StreamID)
-		payload = append(buf, payload...)
-	}
-	s.mu.Unlock()
 
-	if err := handler.OnDAT(stream, payload); err != nil {
-		log.Printf("Handler OnDAT error (stream %d): %v", frame.StreamID, err)
+	var err error
+	if frame.IsMORE() || st.fragmenting {
+		fragmentHandler, ok := st.handler.(streamtype.FragmentHandler)
+		if !ok {
+			return fmt.Errorf("stream type %q does not support fragmented messages", st.handler.Type())
+		}
+		err = fragmentHandler.OnFragment(stream, frame.Payload, frame.IsMORE())
+		st.fragmenting = frame.IsMORE()
+	} else {
+		err = st.handler.OnDAT(stream, frame.Payload)
 	}
+	if err != nil {
+		return err
+	}
+	if err := s.consume(st, frame.FlowBytes()); err != nil {
+		return fmt.Errorf("replenish receive window: %w", err)
+	}
+	return nil
 }
 
 // sendStreamError sends a single-frame error response (SYN+FIN) on the
@@ -248,22 +292,29 @@ func newStreamCtx(s *Session, id uint32) *streamCtx {
 	return &streamCtx{id: id, session: s}
 }
 
-func (s *streamCtx) ID() uint32          { return s.id }
-func (s *streamCtx) ConnectPath() string { return s.session.connectPath }
+func (s *streamCtx) ID() uint32 { return s.id }
+func (s *streamCtx) ConnectPath() string {
+	s.session.mu.Lock()
+	defer s.session.mu.Unlock()
+	return s.session.connectPath
+}
 
 func (s *streamCtx) WriteSYN(payload []byte) error {
-	return s.session.sendFrame(s.id, protocol.FlagSYN, payload)
+	return s.session.sendStreamFrame(s.id, protocol.FlagSYN, payload)
 }
 func (s *streamCtx) WriteDAT(payload []byte) error {
-	return s.session.sendFrame(s.id, protocol.FlagDAT, payload)
+	return s.session.sendStreamFrame(s.id, protocol.FlagDAT, payload)
 }
 func (s *streamCtx) WriteFIN(payload []byte) error {
-	return s.session.sendFrame(s.id, protocol.FlagFIN, payload)
+	return s.session.sendStreamFrame(s.id, protocol.FlagFIN, payload)
 }
 func (s *streamCtx) SendRaw(flags uint16, payload []byte) error {
-	return s.session.sendFrame(s.id, flags, payload)
+	return s.session.sendStreamFrame(s.id, flags, payload)
 }
 func (s *streamCtx) BufferedAmount() uint64 {
+	if s.session.DC == nil {
+		return 0
+	}
 	return s.session.DC.BufferedAmount()
 }
 

--- a/internal/session/session_test.go
+++ b/internal/session/session_test.go
@@ -4,6 +4,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/richlegrand/bitbang/internal/auth"
 	"github.com/richlegrand/bitbang/internal/protocol"
@@ -58,16 +59,29 @@ func newTestSession(t *testing.T, pin string, handler streamtype.StreamHandler) 
 	t.Helper()
 	captured = &atomic.Int64{}
 	sess = &Session{
-		PIN:           auth.New(pin),
-		handlers:      map[string]streamtype.StreamHandler{handler.Type(): handler},
-		streamHandler: make(map[uint32]streamtype.StreamHandler),
-		reasm:         make(map[uint32][]byte),
+		PIN:      auth.New(pin),
+		handlers: map[string]streamtype.StreamHandler{handler.Type(): handler},
+		streams:  make(map[uint32]*streamState),
+		done:     make(chan struct{}),
 	}
 	sess.sendFrame = func(streamID uint32, flags uint16, payload []byte) error {
 		captured.Add(1)
 		return nil
 	}
+	t.Cleanup(sess.Close)
 	return sess, captured
+}
+
+func waitFor(t *testing.T, condition func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		if condition() {
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+	t.Fatal("condition was not met before timeout")
 }
 
 // TestSYNBeforeAuth_Rejected is the regression test for the
@@ -89,9 +103,7 @@ func TestSYNBeforeAuth_Rejected(t *testing.T) {
 	if h.onSYN != 0 {
 		t.Errorf("handler.OnSYN called %d times before auth — gate is broken", h.onSYN)
 	}
-	if sent.Load() == 0 {
-		t.Errorf("session did not emit an error frame for unauthenticated SYN")
-	}
+	waitFor(t, func() bool { return sent.Load() > 0 })
 
 	// Belt-and-suspenders: a DAT on a stream never opened must also
 	// be dropped silently. (handler-nil short-circuit already handles
@@ -164,6 +176,13 @@ func TestSYNAfterAuth_Dispatched(t *testing.T) {
 	syn := protocol.BuildFrame(1, protocol.FlagSYN, []byte(`{"type":"http"}`))
 	sess.HandleMessage(syn)
 
+	waitFor(t, func() bool {
+		h.mu.Lock()
+		defer h.mu.Unlock()
+		return h.onSYN == 1
+	})
+	h.mu.Lock()
+	defer h.mu.Unlock()
 	if h.onSYN != 1 {
 		t.Errorf("handler.OnSYN calls = %d, want 1 after ready=true", h.onSYN)
 	}

--- a/internal/streamtype/file.go
+++ b/internal/streamtype/file.go
@@ -1,6 +1,7 @@
 package streamtype
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"io"
@@ -29,7 +30,7 @@ type Filesystem interface {
 // FileStat is the per-entry metadata returned to clients.
 type FileStat struct {
 	Name     string `json:"name"`
-	Type     string `json:"type"`     // "file" | "directory"
+	Type     string `json:"type"` // "file" | "directory"
 	Size     int64  `json:"size,omitempty"`
 	Modified int64  `json:"modified"` // Unix seconds
 	Mime     string `json:"mime,omitempty"`
@@ -46,14 +47,15 @@ var (
 // operations (get/put/list). Used by `bitbang cp`.
 //
 // Wire shape (see plan / SWSP v3 spec):
-//   get:  client SYN {op:"get",path}  → server SYN {status:"ok",size,...}
-//         server DAT bytes...        → server FIN
-//   put:  client SYN {op:"put",path,overwrite?,size?}
-//         server SYN {status:"ok"}    (ack, ready to receive)
-//         client DAT bytes...        → client FIN
-//         server FIN {status:"ok"} or {error}
-//   list: client SYN {op:"list",path} → server SYN {status:"ok"}
-//         server DAT {entries:[...]} → server FIN
+//
+//	get:  client SYN {op:"get",path}  → server SYN {status:"ok",size,...}
+//	      server DAT bytes...        → server FIN
+//	put:  client SYN {op:"put",path,overwrite?,size?}
+//	      server SYN {status:"ok"}    (ack, ready to receive)
+//	      client DAT bytes...        → client FIN
+//	      server FIN {status:"ok"} or {error}
+//	list: client SYN {op:"list",path} → server SYN {status:"ok"}
+//	      server DAT {entries:[...]} → server FIN
 type FileHandler struct {
 	FS      Filesystem
 	Verbose bool
@@ -63,8 +65,14 @@ type FileHandler struct {
 }
 
 type filePending struct {
-	op string
-	pw *io.PipeWriter
+	op     string
+	pw     *io.PipeWriter
+	closer io.Closer
+	done   chan struct{}
+
+	mu        sync.Mutex
+	closed    bool
+	closeOnce sync.Once
 }
 
 // NewFile constructs a FileHandler backed by the given Filesystem.
@@ -88,7 +96,9 @@ func (h *FileHandler) OnSYN(s Stream, payload []byte, final bool) error {
 
 	switch op.Op {
 	case "get":
-		go h.handleGet(s, op)
+		ps := &filePending{op: "get", done: make(chan struct{})}
+		h.trackStream(s.ID(), ps)
+		go h.handleGet(s, op, ps)
 	case "list":
 		go h.handleList(s, op)
 	case "put":
@@ -115,13 +125,12 @@ func (h *FileHandler) OnSYN(s Stream, payload []byte, final bool) error {
 			return nil
 		}
 		pr, pw := io.Pipe()
-		h.mu.Lock()
-		h.streams[s.ID()] = &filePending{op: "put", pw: pw}
-		h.mu.Unlock()
+		ps := &filePending{op: "put", pw: pw, closer: w, done: make(chan struct{})}
+		h.trackStream(s.ID(), ps)
 		// Ack now that we know OpenWrite succeeded.
 		ack, _ := json.Marshal(map[string]string{"status": "ok"})
 		_ = s.WriteSYN(ack)
-		go h.handlePut(s, op.Path, w, pr)
+		go h.handlePut(s, op.Path, w, pr, ps)
 	default:
 		h.sendFileError(s, "unknown op: "+op.Op)
 	}
@@ -136,7 +145,8 @@ func (h *FileHandler) OnDAT(s Stream, payload []byte) error {
 		return nil
 	}
 	if len(payload) > 0 {
-		_, _ = ps.pw.Write(payload)
+		_, err := ps.pw.Write(payload)
+		return err
 	}
 	return nil
 }
@@ -144,26 +154,39 @@ func (h *FileHandler) OnDAT(s Stream, payload []byte) error {
 func (h *FileHandler) OnFIN(s Stream, payload []byte) error {
 	h.mu.Lock()
 	ps := h.streams[s.ID()]
-	delete(h.streams, s.ID())
 	h.mu.Unlock()
-	if ps == nil {
+	if ps == nil || ps.op != "put" {
 		return nil
 	}
 	if len(payload) > 0 {
-		_, _ = ps.pw.Write(payload)
+		if _, err := ps.pw.Write(payload); err != nil {
+			return err
+		}
 	}
-	_ = ps.pw.Close()
-	return nil
+	return ps.pw.Close()
 }
 
-func (h *FileHandler) handleGet(s Stream, op protocol.FileOp) {
+func (h *FileHandler) OnReset(s Stream, _, _ string) {
+	h.mu.Lock()
+	ps := h.streams[s.ID()]
+	delete(h.streams, s.ID())
+	h.mu.Unlock()
+	if ps != nil {
+		ps.close()
+	}
+}
+
+func (h *FileHandler) handleGet(s Stream, op protocol.FileOp, ps *filePending) {
+	defer h.finishStream(s.ID(), ps)
 	r, stat, err := h.FS.OpenRead(op.Path)
 	if err != nil {
 		log.Printf("Get rejected: %s (%v)", op.Path, err)
 		h.sendFileError(s, fileErrMessage(err, op.Path))
 		return
 	}
-	defer r.Close()
+	if !ps.setCloser(r) {
+		return
+	}
 
 	meta, _ := json.Marshal(map[string]interface{}{
 		"status":   "ok",
@@ -178,11 +201,17 @@ func (h *FileHandler) handleGet(s Stream, op protocol.FileOp) {
 	const maxBuffered = 8 << 20
 	buf := make([]byte, protocol.MaxChunkSize)
 	var total int64
+	backpressureTick := time.NewTicker(time.Millisecond)
+	defer backpressureTick.Stop()
 	for {
 		n, readErr := r.Read(buf)
 		if n > 0 {
 			for s.BufferedAmount() > maxBuffered {
-				time.Sleep(1 * time.Millisecond)
+				select {
+				case <-ps.done:
+					return
+				case <-backpressureTick.C:
+				}
 			}
 			if err := s.WriteDAT(buf[:n]); err != nil {
 				log.Printf("Sent: %s (interrupted after %d bytes: %v)", op.Path, total, err)
@@ -203,8 +232,8 @@ func (h *FileHandler) handleGet(s Stream, op protocol.FileOp) {
 // upload. Mid-stream errors (disk full, broken pipe, etc.) go in the
 // FIN trailer — NOT as a separate SYN — so the client's put loop,
 // which is waiting for FIN by the time we get here, can see them.
-func (h *FileHandler) handlePut(s Stream, path string, w io.WriteCloser, body io.Reader) {
-	defer w.Close()
+func (h *FileHandler) handlePut(s Stream, path string, w io.WriteCloser, body io.Reader, ps *filePending) {
+	defer h.finishStream(s.ID(), ps)
 	n, err := io.Copy(w, body)
 	if err != nil {
 		log.Printf("Put failed mid-stream: %s (after %d bytes: %v)", path, n, err)
@@ -220,6 +249,56 @@ func (h *FileHandler) handlePut(s Stream, path string, w io.WriteCloser, body io
 	_ = s.WriteFIN(done)
 }
 
+func (h *FileHandler) trackStream(id uint32, ps *filePending) {
+	h.mu.Lock()
+	old := h.streams[id]
+	h.streams[id] = ps
+	h.mu.Unlock()
+	if old != nil {
+		old.close()
+	}
+}
+
+func (h *FileHandler) finishStream(id uint32, want *filePending) {
+	h.mu.Lock()
+	if h.streams[id] == want {
+		delete(h.streams, id)
+	}
+	h.mu.Unlock()
+	want.close()
+}
+
+func (ps *filePending) setCloser(closer io.Closer) bool {
+	ps.mu.Lock()
+	if ps.closed {
+		ps.mu.Unlock()
+		_ = closer.Close()
+		return false
+	}
+	ps.closer = closer
+	ps.mu.Unlock()
+	return true
+}
+
+func (ps *filePending) close() {
+	ps.closeOnce.Do(func() {
+		if ps.done != nil {
+			close(ps.done)
+		}
+		ps.mu.Lock()
+		ps.closed = true
+		pw := ps.pw
+		closer := ps.closer
+		ps.mu.Unlock()
+		if pw != nil {
+			_ = pw.CloseWithError(context.Canceled)
+		}
+		if closer != nil {
+			_ = closer.Close()
+		}
+	})
+}
+
 func (h *FileHandler) handleList(s Stream, op protocol.FileOp) {
 	entries, err := h.FS.ListPath(op.Path)
 	if err != nil {
@@ -228,12 +307,16 @@ func (h *FileHandler) handleList(s Stream, op protocol.FileOp) {
 		return
 	}
 	log.Printf("Listed: %s (%d entries)", op.Path, len(entries))
+	body, _ := json.Marshal(map[string]interface{}{"entries": entries})
+	if err := protocol.ValidateFramePayload(body); err != nil {
+		h.sendFileError(s, "directory listing is too large")
+		return
+	}
 
 	hdr, _ := json.Marshal(map[string]string{"status": "ok"})
 	if err := s.WriteSYN(hdr); err != nil {
 		return
 	}
-	body, _ := json.Marshal(map[string]interface{}{"entries": entries})
 	_ = s.WriteDAT(body)
 	_ = s.WriteFIN(nil)
 }

--- a/internal/streamtype/http.go
+++ b/internal/streamtype/http.go
@@ -1,7 +1,6 @@
 package streamtype
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -73,8 +72,8 @@ func NewHTTPProxy(target, uid, server, browserIP string, verbose bool) *HTTPHand
 }
 
 type pendingStream struct {
-	req protocol.Request
-	pw  *io.PipeWriter
+	pw     *io.PipeWriter
+	cancel context.CancelFunc
 }
 
 // Type implements StreamHandler.
@@ -280,17 +279,26 @@ func (h *HTTPHandler) OnSYN(s Stream, payload []byte, final bool) error {
 		return nil
 	}
 
-	if final {
-		go h.proxyRequest(s, req, nil)
-		return nil
+	ctx, cancel := context.WithCancel(context.Background())
+	ps := &pendingStream{cancel: cancel}
+	var body io.Reader
+	if !final {
+		pr, pw := io.Pipe()
+		ps.pw = pw
+		body = pr
+	}
+	h.mu.Lock()
+	old := h.streams[s.ID()]
+	h.streams[s.ID()] = ps
+	h.mu.Unlock()
+	if old != nil {
+		old.close()
 	}
 
-	pr, pw := io.Pipe()
-	h.mu.Lock()
-	h.streams[s.ID()] = &pendingStream{req: req, pw: pw}
-	h.mu.Unlock()
-
-	go h.proxyRequest(s, req, pr)
+	go func() {
+		defer h.finishStream(s.ID(), ps)
+		h.proxyRequestContext(ctx, s, req, body)
+	}()
 	return nil
 }
 
@@ -299,11 +307,12 @@ func (h *HTTPHandler) OnDAT(s Stream, payload []byte) error {
 	h.mu.Lock()
 	ps := h.streams[s.ID()]
 	h.mu.Unlock()
-	if ps == nil {
+	if ps == nil || ps.pw == nil {
 		return nil
 	}
 	if len(payload) > 0 {
-		_, _ = ps.pw.Write(payload)
+		_, err := ps.pw.Write(payload)
+		return err
 	}
 	return nil
 }
@@ -313,19 +322,33 @@ func (h *HTTPHandler) OnDAT(s Stream, payload []byte) error {
 func (h *HTTPHandler) OnFIN(s Stream, payload []byte) error {
 	h.mu.Lock()
 	ps := h.streams[s.ID()]
-	delete(h.streams, s.ID())
 	h.mu.Unlock()
-	if ps == nil {
+	if ps == nil || ps.pw == nil {
 		return nil
 	}
 	if len(payload) > 0 {
-		_, _ = ps.pw.Write(payload)
+		if _, err := ps.pw.Write(payload); err != nil {
+			return err
+		}
 	}
-	_ = ps.pw.Close()
-	return nil
+	return ps.pw.Close()
+}
+
+func (h *HTTPHandler) OnReset(s Stream, _, _ string) {
+	h.mu.Lock()
+	ps := h.streams[s.ID()]
+	delete(h.streams, s.ID())
+	h.mu.Unlock()
+	if ps != nil {
+		ps.close()
+	}
 }
 
 func (h *HTTPHandler) proxyRequest(s Stream, req protocol.Request, body io.Reader) {
+	h.proxyRequestContext(context.Background(), s, req, body)
+}
+
+func (h *HTTPHandler) proxyRequestContext(ctx context.Context, s Stream, req protocol.Request, body io.Reader) {
 	if h.connTarget == "" {
 		h.serveLandingPage(s, req)
 		return
@@ -334,22 +357,17 @@ func (h *HTTPHandler) proxyRequest(s Stream, req protocol.Request, body io.Reade
 	target, pathname := h.resolveTarget(req.Pathname)
 	url := fmt.Sprintf("%s://%s%s", h.scheme(), target, pathname)
 
-	// Buffer the body so Content-Length is explicit (many embedded
-	// servers don't support chunked encoding).
+	// Stream request bytes directly into the upstream transport. Flow-control
+	// credit is returned only when this reader advances, so a slow target cannot
+	// turn an upload into an unbounded in-memory buffer. Browsers supply the
+	// length for ordinary form/file bodies; preserving it avoids chunked
+	// encoding for embedded servers that require Content-Length.
 	var reqBody io.Reader
-	var reqLen int64
 	if body != nil {
-		bodyBytes, err := io.ReadAll(body)
-		if err != nil {
-			log.Printf("Failed to read request body: %v", err)
-			h.sendError(s, 500, "Internal error")
-			return
-		}
-		reqBody = bytes.NewReader(bodyBytes)
-		reqLen = int64(len(bodyBytes))
+		reqBody = body
 	}
 
-	httpReq, err := http.NewRequest(req.Method, url, reqBody)
+	httpReq, err := http.NewRequestWithContext(ctx, req.Method, url, reqBody)
 	if err != nil {
 		log.Printf("Failed to create HTTP request: %v", err)
 		h.sendError(s, 500, "Internal error")
@@ -377,8 +395,8 @@ func (h *HTTPHandler) proxyRequest(s Stream, req protocol.Request, body io.Reade
 			httpReq.Header.Set("Content-Type", req.ContentType)
 		}
 	}
-	if reqLen > 0 {
-		httpReq.ContentLength = reqLen
+	if body != nil && req.ContentLength > 0 {
+		httpReq.ContentLength = int64(req.ContentLength)
 	}
 	httpReq.Host = target
 	httpReq.Header.Set("X-Forwarded-Host", h.Server)
@@ -418,6 +436,9 @@ func (h *HTTPHandler) proxyRequest(s Stream, req protocol.Request, body io.Reade
 
 	resp, err := client.Do(httpReq)
 	if err != nil {
+		if ctx.Err() != nil {
+			return
+		}
 		log.Printf("Proxy request failed: %s %s -> %v", req.Method, req.Pathname, err)
 		h.sendError(s, 502, "Target unreachable")
 		return
@@ -469,6 +490,11 @@ func (h *HTTPHandler) proxyRequest(s Stream, req protocol.Request, body io.Reade
 		"headers": headers,
 	}
 	respJSON, _ := json.Marshal(respMeta)
+	if err := protocol.ValidateFramePayload(respJSON); err != nil {
+		log.Printf("HTTP response headers exceed SWSP frame limit: %v", err)
+		h.sendError(s, 502, "Response headers are too large")
+		return
+	}
 	if err := s.WriteSYN(respJSON); err != nil {
 		return
 	}
@@ -478,11 +504,17 @@ func (h *HTTPHandler) proxyRequest(s Stream, req protocol.Request, body io.Reade
 	totalBytes := 0
 	startTime := time.Now()
 	nextLogMB := 50
+	backpressureTick := time.NewTicker(time.Millisecond)
+	defer backpressureTick.Stop()
 	for {
 		n, readErr := resp.Body.Read(buf)
 		if n > 0 {
 			for s.BufferedAmount() > maxBuffered {
-				time.Sleep(1 * time.Millisecond)
+				select {
+				case <-ctx.Done():
+					return
+				case <-backpressureTick.C:
+				}
 			}
 			if err := s.WriteDAT(buf[:n]); err != nil {
 				log.Printf("WriteDAT failed (stream %d, %d bytes sent so far): %v", s.ID(), totalBytes, err)
@@ -508,6 +540,22 @@ func (h *HTTPHandler) proxyRequest(s Stream, req protocol.Request, body io.Reade
 
 	if h.Verbose || resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		log.Printf("%s %s -> %d (%d bytes)", req.Method, pathname, resp.StatusCode, totalBytes)
+	}
+}
+
+func (h *HTTPHandler) finishStream(id uint32, want *pendingStream) {
+	h.mu.Lock()
+	if h.streams[id] == want {
+		delete(h.streams, id)
+	}
+	h.mu.Unlock()
+	want.close()
+}
+
+func (ps *pendingStream) close() {
+	ps.cancel()
+	if ps.pw != nil {
+		_ = ps.pw.CloseWithError(context.Canceled)
 	}
 }
 

--- a/internal/streamtype/http_flow_test.go
+++ b/internal/streamtype/http_flow_test.go
@@ -1,0 +1,108 @@
+package streamtype
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/richlegrand/bitbang/internal/protocol"
+)
+
+type httpRecordingStream struct {
+	mu     sync.Mutex
+	frames []protocol.Frame
+}
+
+func (*httpRecordingStream) ID() uint32          { return 1 }
+func (*httpRecordingStream) ConnectPath() string { return "/" }
+func (s *httpRecordingStream) WriteSYN(payload []byte) error {
+	return s.record(protocol.FlagSYN, payload)
+}
+func (s *httpRecordingStream) WriteDAT(payload []byte) error {
+	return s.record(protocol.FlagDAT, payload)
+}
+func (s *httpRecordingStream) WriteFIN(payload []byte) error {
+	return s.record(protocol.FlagFIN, payload)
+}
+func (s *httpRecordingStream) SendRaw(flags uint16, payload []byte) error {
+	return s.record(flags, payload)
+}
+func (*httpRecordingStream) BufferedAmount() uint64 { return 0 }
+
+func (s *httpRecordingStream) record(flags uint16, payload []byte) error {
+	if err := protocol.ValidateFramePayload(payload); err != nil {
+		return err
+	}
+	s.mu.Lock()
+	s.frames = append(s.frames, protocol.Frame{
+		StreamID: 1,
+		Flags:    flags,
+		Payload:  append([]byte(nil), payload...),
+	})
+	s.mu.Unlock()
+	return nil
+}
+
+func (s *httpRecordingStream) snapshot() []protocol.Frame {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]protocol.Frame(nil), s.frames...)
+}
+
+func assertHeaderLimitResponse(t *testing.T, frames []protocol.Frame) {
+	t.Helper()
+	if len(frames) != 3 {
+		t.Fatalf("response frame count = %d, want 3: %#v", len(frames), frames)
+	}
+	var meta struct {
+		Status int `json:"status"`
+	}
+	if !frames[0].IsSYN() || json.Unmarshal(frames[0].Payload, &meta) != nil || meta.Status != 502 {
+		t.Fatalf("response SYN = %#v, metadata = %#v; want status 502", frames[0], meta)
+	}
+	if got := string(frames[1].Payload); got != "Response headers are too large" {
+		t.Fatalf("response body = %q", got)
+	}
+	if !frames[2].IsFIN() {
+		t.Fatalf("terminal frame flags = %#x, want FIN", frames[2].Flags)
+	}
+}
+
+func TestHTTPProxyRejectsOversizedResponseHeadersCoherently(t *testing.T) {
+	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("X-Oversized", strings.Repeat("x", protocol.MaxChunkSize))
+		_, _ = w.Write([]byte("must not be forwarded"))
+	}))
+	defer target.Close()
+
+	host := strings.TrimPrefix(target.URL, "http://")
+	h := &HTTPHandler{
+		Target:     host,
+		connTarget: host,
+		Server:     "bitba.ng",
+		streams:    make(map[uint32]*pendingStream),
+	}
+	stream := &httpRecordingStream{}
+	h.proxyRequest(stream, protocol.Request{Method: http.MethodGet, Pathname: "/"}, nil)
+
+	assertHeaderLimitResponse(t, stream.snapshot())
+}
+
+func TestHTTPLocalRejectsOversizedResponseHeadersBeforeBody(t *testing.T) {
+	stream := &httpRecordingStream{}
+	w := &swspResponseWriter{
+		stream:  stream,
+		status:  http.StatusOK,
+		headers: http.Header{"X-Oversized": []string{strings.Repeat("x", protocol.MaxChunkSize)}},
+		done:    make(chan struct{}),
+	}
+
+	if n, err := w.Write([]byte("must not be forwarded")); err == nil || n != 0 {
+		t.Fatalf("oversized-header Write = %d, %v; want 0, error", n, err)
+	}
+	w.Close()
+	assertHeaderLimitResponse(t, stream.snapshot())
+}

--- a/internal/streamtype/http_local.go
+++ b/internal/streamtype/http_local.go
@@ -1,6 +1,7 @@
 package streamtype
 
 import (
+	"context"
 	"encoding/json"
 	"io"
 	"log"
@@ -36,7 +37,8 @@ func NewHTTPLocal(h http.Handler, verbose bool) *HTTPLocalHandler {
 }
 
 type localPending struct {
-	pw *io.PipeWriter
+	pw     *io.PipeWriter
+	cancel context.CancelFunc
 }
 
 func (h *HTTPLocalHandler) Type() string             { return "http" }
@@ -48,15 +50,25 @@ func (h *HTTPLocalHandler) OnSYN(s Stream, payload []byte, final bool) error {
 		sendStreamError(s, 400, "Bad request")
 		return nil
 	}
-	if final {
-		go h.dispatch(s, req, nil)
-		return nil
+	ctx, cancel := context.WithCancel(context.Background())
+	ps := &localPending{cancel: cancel}
+	var body io.Reader
+	if !final {
+		pr, pw := io.Pipe()
+		ps.pw = pw
+		body = pr
 	}
-	pr, pw := io.Pipe()
 	h.mu.Lock()
-	h.streams[s.ID()] = &localPending{pw: pw}
+	old := h.streams[s.ID()]
+	h.streams[s.ID()] = ps
 	h.mu.Unlock()
-	go h.dispatch(s, req, pr)
+	if old != nil {
+		old.close()
+	}
+	go func() {
+		defer h.finishStream(s.ID(), ps)
+		h.dispatch(ctx, s, req, body)
+	}()
 	return nil
 }
 
@@ -64,11 +76,12 @@ func (h *HTTPLocalHandler) OnDAT(s Stream, payload []byte) error {
 	h.mu.Lock()
 	ps := h.streams[s.ID()]
 	h.mu.Unlock()
-	if ps == nil {
+	if ps == nil || ps.pw == nil {
 		return nil
 	}
 	if len(payload) > 0 {
-		_, _ = ps.pw.Write(payload)
+		_, err := ps.pw.Write(payload)
+		return err
 	}
 	return nil
 }
@@ -76,23 +89,33 @@ func (h *HTTPLocalHandler) OnDAT(s Stream, payload []byte) error {
 func (h *HTTPLocalHandler) OnFIN(s Stream, payload []byte) error {
 	h.mu.Lock()
 	ps := h.streams[s.ID()]
-	delete(h.streams, s.ID())
 	h.mu.Unlock()
-	if ps == nil {
+	if ps == nil || ps.pw == nil {
 		return nil
 	}
 	if len(payload) > 0 {
-		_, _ = ps.pw.Write(payload)
+		if _, err := ps.pw.Write(payload); err != nil {
+			return err
+		}
 	}
-	_ = ps.pw.Close()
-	return nil
+	return ps.pw.Close()
 }
 
-func (h *HTTPLocalHandler) dispatch(s Stream, req protocol.Request, body io.Reader) {
+func (h *HTTPLocalHandler) OnReset(s Stream, _, _ string) {
+	h.mu.Lock()
+	ps := h.streams[s.ID()]
+	delete(h.streams, s.ID())
+	h.mu.Unlock()
+	if ps != nil {
+		ps.close()
+	}
+}
+
+func (h *HTTPLocalHandler) dispatch(ctx context.Context, s Stream, req protocol.Request, body io.Reader) {
 	if body == nil {
 		body = http.NoBody
 	}
-	httpReq, err := http.NewRequest(req.Method, req.Pathname, body)
+	httpReq, err := http.NewRequestWithContext(ctx, req.Method, req.Pathname, body)
 	if err != nil {
 		sendStreamError(s, 500, err.Error())
 		return
@@ -104,12 +127,28 @@ func (h *HTTPLocalHandler) dispatch(s Stream, req protocol.Request, body io.Read
 		httpReq.ContentLength = int64(req.ContentLength)
 	}
 
-	rw := &swspResponseWriter{stream: s, status: 200, headers: http.Header{}}
+	rw := &swspResponseWriter{stream: s, status: 200, headers: http.Header{}, done: ctx.Done()}
 	h.Handler.ServeHTTP(rw, httpReq)
 	rw.Close()
 
 	if h.Verbose {
 		log.Printf("local %s %s -> %d", req.Method, req.Pathname, rw.status)
+	}
+}
+
+func (h *HTTPLocalHandler) finishStream(id uint32, want *localPending) {
+	h.mu.Lock()
+	if h.streams[id] == want {
+		delete(h.streams, id)
+	}
+	h.mu.Unlock()
+	want.close()
+}
+
+func (ps *localPending) close() {
+	ps.cancel()
+	if ps.pw != nil {
+		_ = ps.pw.CloseWithError(context.Canceled)
 	}
 }
 
@@ -123,6 +162,8 @@ type swspResponseWriter struct {
 	headers    http.Header
 	headerSent bool
 	closed     bool
+	writeErr   error
+	done       <-chan struct{}
 }
 
 func (w *swspResponseWriter) Header() http.Header { return w.headers }
@@ -139,14 +180,23 @@ func (w *swspResponseWriter) Write(p []byte) (int, error) {
 	if !w.headerSent {
 		w.sendHeader()
 	}
+	if w.writeErr != nil {
+		return 0, w.writeErr
+	}
 	if len(p) == 0 {
 		return 0, nil
 	}
 	// Backpressure: mirror what HTTPHandler does — cap the data channel
 	// send buffer at 8 MB so a slow consumer doesn't blow up memory.
 	const maxBuffered = 8 << 20
+	backpressureTick := time.NewTicker(time.Millisecond)
+	defer backpressureTick.Stop()
 	for w.stream.BufferedAmount() > maxBuffered {
-		time.Sleep(1 * time.Millisecond)
+		select {
+		case <-w.done:
+			return 0, context.Canceled
+		case <-backpressureTick.C:
+		}
 	}
 	// Chunk the write to fit within SWSP's max frame payload.
 	written := 0
@@ -177,7 +227,16 @@ func (w *swspResponseWriter) sendHeader() {
 		"status":  w.status,
 		"headers": headers,
 	})
-	_ = w.stream.WriteSYN(meta)
+	if err := protocol.ValidateFramePayload(meta); err != nil {
+		w.writeErr = err
+		w.closed = true
+		sendStreamError(w.stream, 502, "Response headers are too large")
+		return
+	}
+	if err := w.stream.WriteSYN(meta); err != nil {
+		w.writeErr = err
+		w.closed = true
+	}
 }
 
 // Close finalizes the response: sends headers if not yet sent, then FIN.

--- a/internal/streamtype/shell.go
+++ b/internal/streamtype/shell.go
@@ -634,6 +634,20 @@ func (h *ShellHandler) OnFIN(s Stream, _ []byte) error {
 	return nil
 }
 
+func (h *ShellHandler) OnReset(s Stream, _, _ string) {
+	h.mu.Lock()
+	sess := h.streams[s.ID()]
+	h.mu.Unlock()
+	if sess == nil {
+		return
+	}
+	sess.output.cancel()
+	if sess.process != nil {
+		_ = terminateShellProcess(sess.process)
+	}
+	sess.closeInput()
+}
+
 func (h *ShellHandler) closeStdin(streamID uint32) {
 	h.mu.Lock()
 	sess := h.streams[streamID]

--- a/internal/streamtype/streamtype.go
+++ b/internal/streamtype/streamtype.go
@@ -53,3 +53,16 @@ type StreamHandler interface {
 	// handling. The handler should clean up any per-stream state.
 	OnFIN(s Stream, payload []byte) error
 }
+
+// FragmentHandler is implemented by stream types that preserve message
+// boundaries across SWSP MORE frames. The first fragment carries any
+// stream-specific metadata; subsequent fragments contain continuation bytes.
+type FragmentHandler interface {
+	OnFragment(s Stream, payload []byte, more bool) error
+}
+
+// ResetHandler is implemented by handlers with resources that must be released
+// when one stream is aborted without closing the rest of the session.
+type ResetHandler interface {
+	OnReset(s Stream, code, message string)
+}

--- a/internal/streamtype/tcp.go
+++ b/internal/streamtype/tcp.go
@@ -38,19 +38,19 @@ type TCPHandler struct {
 	active  int
 }
 
-type tcpInbound struct {
-	data []byte
-	fin  bool
-}
-
 type tcpStream struct {
-	ctx     context.Context
-	cancel  context.CancelFunc
-	stream  Stream
-	inbound chan tcpInbound
+	ctx    context.Context
+	cancel context.CancelFunc
+	stream Stream
+	ready  chan struct{}
 
-	mu   sync.Mutex
-	conn net.Conn
+	mu      sync.Mutex
+	conn    net.Conn
+	dialErr error
+	writeMu sync.Mutex
+
+	writeDone     chan struct{}
+	writeDoneOnce sync.Once
 }
 
 // NewTCP returns a per-WebRTC-session TCP handler.
@@ -90,10 +90,11 @@ func (h *TCPHandler) OnSYN(s Stream, payload []byte, final bool) error {
 	}
 	ctx, cancel := context.WithCancel(h.ctx)
 	ts := &tcpStream{
-		ctx:     ctx,
-		cancel:  cancel,
-		stream:  s,
-		inbound: make(chan tcpInbound, 256),
+		ctx:       ctx,
+		cancel:    cancel,
+		stream:    s,
+		ready:     make(chan struct{}),
+		writeDone: make(chan struct{}),
 	}
 	h.streams[s.ID()] = ts
 	h.active++
@@ -102,10 +103,7 @@ func (h *TCPHandler) OnSYN(s Stream, payload []byte, final bool) error {
 		old.close()
 	}
 
-	if final {
-		ts.inbound <- tcpInbound{fin: true}
-	}
-	go h.runStream(ts, open)
+	go h.runStream(ts, open, final)
 	return nil
 }
 
@@ -114,13 +112,11 @@ func (h *TCPHandler) OnDAT(s Stream, payload []byte) error {
 	if ts == nil {
 		return nil
 	}
-	data := append([]byte(nil), payload...)
-	select {
-	case ts.inbound <- tcpInbound{data: data}:
-		return nil
-	case <-ts.ctx.Done():
-		return ts.ctx.Err()
+	if err := ts.write(payload); err != nil {
+		ts.close()
+		return err
 	}
+	return nil
 }
 
 func (h *TCPHandler) OnFIN(s Stream, payload []byte) error {
@@ -133,15 +129,20 @@ func (h *TCPHandler) OnFIN(s Stream, payload []byte) error {
 			return err
 		}
 	}
-	select {
-	case ts.inbound <- tcpInbound{fin: true}:
-		return nil
-	case <-ts.ctx.Done():
-		return ts.ctx.Err()
+	if err := ts.closeWrite(); err != nil {
+		ts.close()
+		return err
+	}
+	return nil
+}
+
+func (h *TCPHandler) OnReset(s Stream, _, _ string) {
+	if ts := h.lookup(s.ID()); ts != nil {
+		ts.close()
 	}
 }
 
-func (h *TCPHandler) runStream(ts *tcpStream, open protocol.TCPOpen) {
+func (h *TCPHandler) runStream(ts *tcpStream, open protocol.TCPOpen, final bool) {
 	defer h.remove(ts.stream.ID(), ts)
 
 	address := net.JoinHostPort(open.Host, strconv.Itoa(open.Port))
@@ -150,10 +151,11 @@ func (h *TCPHandler) runStream(ts *tcpStream, open protocol.TCPOpen) {
 		if ts.ctx.Err() == nil {
 			h.sendError(ts.stream, "dial "+address+": "+err.Error())
 		}
+		ts.finishDial(nil, err)
 		ts.cancel()
 		return
 	}
-	if !ts.setConn(conn) {
+	if !ts.finishDial(conn, nil) {
 		_ = conn.Close()
 		return
 	}
@@ -168,41 +170,24 @@ func (h *TCPHandler) runStream(ts *tcpStream, open protocol.TCPOpen) {
 		log.Printf("TCP stream %d connected to %s", ts.stream.ID(), address)
 	}
 
-	done := make(chan error, 2)
-	go func() { done <- h.writeTarget(ts, conn) }()
-	go func() {
-		_, err := bytestream.Pump(ts.ctx, conn, ts.stream)
-		done <- err
-	}()
-
-	for i := 0; i < 2; i++ {
-		if pumpErr := <-done; pumpErr != nil && ts.ctx.Err() == nil {
-			ts.cancel()
-			_ = conn.Close()
+	if final {
+		if err := ts.closeWrite(); err != nil {
+			ts.close()
+			return
 		}
 	}
-	ts.cancel()
-	_ = conn.Close()
+
+	_, pumpErr := bytestream.Pump(ts.ctx, conn, ts.stream)
+	if pumpErr == nil {
+		_ = bytestream.CloseRead(conn)
+		select {
+		case <-ts.writeDone:
+		case <-ts.ctx.Done():
+		}
+	}
+	ts.close()
 	if h.Verbose {
 		log.Printf("TCP stream %d closed (%s)", ts.stream.ID(), address)
-	}
-}
-
-func (h *TCPHandler) writeTarget(ts *tcpStream, conn net.Conn) error {
-	for {
-		select {
-		case <-ts.ctx.Done():
-			return ts.ctx.Err()
-		case in := <-ts.inbound:
-			if len(in.data) > 0 {
-				if err := bytestream.WriteFull(conn, in.data); err != nil {
-					return err
-				}
-			}
-			if in.fin {
-				return bytestream.CloseWrite(conn)
-			}
-		}
 	}
 }
 
@@ -221,14 +206,57 @@ func (h *TCPHandler) remove(id uint32, want *tcpStream) {
 	h.mu.Unlock()
 }
 
-func (ts *tcpStream) setConn(conn net.Conn) bool {
+func (ts *tcpStream) finishDial(conn net.Conn, err error) bool {
 	ts.mu.Lock()
 	defer ts.mu.Unlock()
 	if ts.ctx.Err() != nil {
+		ts.dialErr = ts.ctx.Err()
+		close(ts.ready)
 		return false
 	}
 	ts.conn = conn
+	ts.dialErr = err
+	close(ts.ready)
 	return true
+}
+
+func (ts *tcpStream) waitConn() (net.Conn, error) {
+	select {
+	case <-ts.ready:
+		ts.mu.Lock()
+		defer ts.mu.Unlock()
+		if ts.conn != nil {
+			return ts.conn, nil
+		}
+		if ts.dialErr != nil {
+			return nil, ts.dialErr
+		}
+		return nil, net.ErrClosed
+	case <-ts.ctx.Done():
+		return nil, ts.ctx.Err()
+	}
+}
+
+func (ts *tcpStream) write(payload []byte) error {
+	conn, err := ts.waitConn()
+	if err != nil {
+		return err
+	}
+	ts.writeMu.Lock()
+	defer ts.writeMu.Unlock()
+	return bytestream.WriteFull(conn, payload)
+}
+
+func (ts *tcpStream) closeWrite() error {
+	conn, err := ts.waitConn()
+	if err != nil {
+		return err
+	}
+	ts.writeMu.Lock()
+	err = bytestream.CloseWrite(conn)
+	ts.writeMu.Unlock()
+	ts.writeDoneOnce.Do(func() { close(ts.writeDone) })
+	return err
 }
 
 func (ts *tcpStream) close() {

--- a/internal/streamtype/tcp_test.go
+++ b/internal/streamtype/tcp_test.go
@@ -210,6 +210,42 @@ func TestTCPHandlerCloseAllCancelsPendingDial(t *testing.T) {
 	}
 }
 
+func TestTCPHandlerResetUnblocksStalledTargetWrite(t *testing.T) {
+	conn, target := net.Pipe()
+	defer target.Close()
+
+	h := NewTCP(false)
+	h.DialContext = func(context.Context, string, string) (net.Conn, error) {
+		return conn, nil
+	}
+	s := newTCPTestStream()
+	tcpSYN(t, h, s, "127.0.0.1", 9000)
+	if ack := nextTCPFrame(t, s); !ack.IsSYN() || ack.IsFIN() {
+		t.Fatalf("ack flags = %#x, want SYN", ack.Flags)
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		done <- h.OnDAT(s, bytes.Repeat([]byte("x"), protocol.MaxChunkSize))
+	}()
+	select {
+	case err := <-done:
+		t.Fatalf("stalled target write returned early: %v", err)
+	case <-time.After(20 * time.Millisecond):
+	}
+
+	h.OnReset(s, "canceled", "test reset")
+	h.OnReset(s, "canceled", "duplicate reset")
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("stalled target write returned nil after reset")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("reset did not unblock stalled target write")
+	}
+}
+
 func TestTCPHandlerRejectsStreamsOverLimit(t *testing.T) {
 	started := make(chan struct{}, 2)
 	finished := make(chan struct{}, 2)
@@ -258,3 +294,4 @@ func TestTCPHandlerRejectsStreamsOverLimit(t *testing.T) {
 
 var _ net.Conn = (*shortConn)(nil)
 var _ io.Writer = (*shortConn)(nil)
+var _ ResetHandler = (*TCPHandler)(nil)

--- a/internal/streamtype/websocket.go
+++ b/internal/streamtype/websocket.go
@@ -1,15 +1,19 @@
 package streamtype
 
 import (
+	"bufio"
+	"context"
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
+	"io"
 	"log"
 	"net"
 	"net/http"
 	"sync"
 
 	"github.com/gorilla/websocket"
+	"github.com/richlegrand/bitbang/internal/bytestream"
 	"github.com/richlegrand/bitbang/internal/localdns"
 	"github.com/richlegrand/bitbang/internal/protocol"
 )
@@ -74,7 +78,14 @@ func NewWebSocket(resolver TargetResolver, browserIP string, verbose bool) *WSHa
 }
 
 type wsStream struct {
+	ctx    context.Context
+	cancel context.CancelFunc
+
+	mu   sync.Mutex
 	conn *websocket.Conn
+
+	writeMu sync.Mutex
+	writer  io.WriteCloser
 }
 
 func (h *WSHandler) Type() string { return "websocket" }
@@ -91,27 +102,36 @@ func (h *WSHandler) OnSYN(s Stream, payload []byte, _ bool) error {
 		log.Printf("Failed to parse WS open: %v", err)
 		return nil
 	}
-	go h.bridge(s, msg.Pathname, msg.Cookies)
+	ctx, cancel := context.WithCancel(context.Background())
+	ws := &wsStream{ctx: ctx, cancel: cancel}
+	h.mu.Lock()
+	old := h.streams[s.ID()]
+	h.streams[s.ID()] = ws
+	h.mu.Unlock()
+	if old != nil {
+		old.close()
+	}
+	go h.bridge(s, ws, msg.Pathname, msg.Cookies)
 	return nil
 }
 
 // OnDAT forwards a message from the browser to the local WS server.
 func (h *WSHandler) OnDAT(s Stream, payload []byte) error {
+	return h.OnFragment(s, payload, false)
+}
+
+// OnFragment streams one browser message into a single upstream WebSocket
+// writer without assembling it in the session receive loop.
+func (h *WSHandler) OnFragment(s Stream, payload []byte, more bool) error {
 	h.mu.Lock()
 	ws := h.streams[s.ID()]
 	h.mu.Unlock()
-	if ws == nil || len(payload) < 1 {
+	if ws == nil {
 		return nil
 	}
-	typeByte := payload[0]
-	data := payload[1:]
-	msgType := websocket.TextMessage
-	if typeByte == 1 {
-		msgType = websocket.BinaryMessage
-	}
-	if err := ws.conn.WriteMessage(msgType, data); err != nil {
-		log.Printf("WS write failed (stream %d): %v", s.ID(), err)
-		ws.conn.Close()
+	if err := ws.writeFragment(payload, more); err != nil {
+		ws.close()
+		return err
 	}
 	return nil
 }
@@ -123,12 +143,22 @@ func (h *WSHandler) OnFIN(s Stream, _ []byte) error {
 	delete(h.streams, s.ID())
 	h.mu.Unlock()
 	if ws != nil {
-		ws.conn.Close()
+		ws.close()
 	}
 	return nil
 }
 
-func (h *WSHandler) bridge(s Stream, pathname, cookies string) {
+func (h *WSHandler) OnReset(s Stream, _, _ string) {
+	h.mu.Lock()
+	ws := h.streams[s.ID()]
+	delete(h.streams, s.ID())
+	h.mu.Unlock()
+	if ws != nil {
+		ws.close()
+	}
+}
+
+func (h *WSHandler) bridge(s Stream, ws *wsStream, pathname, cookies string) {
 	target, wsPath := h.Resolver.ResolveTarget(pathname)
 
 	// An HTTPS session must dial wss://, or the handshake hits a TLS port
@@ -153,66 +183,154 @@ func (h *WSHandler) bridge(s Stream, pathname, cookies string) {
 	if ip := net.ParseIP(h.BrowserIP); ip != nil {
 		header.Set("X-Forwarded-For", ip.String())
 	}
-	conn, _, err := dialer.Dial(wsURL, header)
+	conn, _, err := dialer.DialContext(ws.ctx, wsURL, header)
 	if err != nil {
-		log.Printf("WS connect failed: %s -> %v", pathname, err)
-		_ = s.WriteFIN(nil)
+		if ws.ctx.Err() == nil {
+			log.Printf("WS connect failed: %s -> %v", pathname, err)
+			_ = s.WriteFIN(nil)
+		}
+		h.remove(s.ID(), ws)
+		return
+	}
+	if !ws.setConn(conn) {
+		_ = conn.Close()
+		h.remove(s.ID(), ws)
 		return
 	}
 	log.Printf("WS opened: %s (stream %d)", pathname, s.ID())
 
-	h.mu.Lock()
-	h.streams[s.ID()] = &wsStream{conn: conn}
-	h.mu.Unlock()
-
 	_ = s.WriteSYN(nil)
 
 	defer func() {
-		conn.Close()
-		h.mu.Lock()
-		delete(h.streams, s.ID())
-		h.mu.Unlock()
+		ws.close()
+		h.remove(s.ID(), ws)
 		_ = s.WriteFIN(nil)
 		log.Printf("WS closed: %s (stream %d)", pathname, s.ID())
 	}()
 
 	for {
-		msgType, data, err := conn.ReadMessage()
+		msgType, reader, err := conn.NextReader()
 		if err != nil {
 			return
 		}
-		var typeByte byte
-		if msgType == websocket.TextMessage {
-			typeByte = 0
-		} else {
-			typeByte = 1
-		}
-		buf := make([]byte, 1+len(data))
-		buf[0] = typeByte
-		copy(buf[1:], data)
-		// The data channel caps messages at MaxChunkSize and the SWSP
-		// length field is 16-bit, so a large WS message must be split
-		// across frames. Non-final chunks carry FlagMORE; the receiver
-		// reassembles them into one WS message (the type byte rides in
-		// the first chunk).
-		if err := writeWSChunks(s, buf); err != nil {
+		if err := writeWSReader(s, msgType, reader); err != nil {
 			return
 		}
 	}
 }
 
-// writeWSChunks sends one WebSocket message as one or more SWSP DAT frames,
-// each at most MaxChunkSize bytes. Every chunk but the last carries FlagMORE
-// so the receiver reassembles them back into a single WS message.
-func writeWSChunks(s Stream, buf []byte) error {
-	for off := 0; off < len(buf); off += protocol.MaxChunkSize {
-		end := off + protocol.MaxChunkSize
-		if end >= len(buf) {
-			return s.WriteDAT(buf[off:]) // final chunk: FlagDAT, no MORE
+// writeWSReader sends one WebSocket message as bounded SWSP fragments. The
+// one-byte lookahead determines MORE without reading the whole message.
+func writeWSReader(s Stream, msgType int, src io.Reader) error {
+	reader := bufio.NewReaderSize(src, protocol.MaxChunkSize)
+	buf := make([]byte, protocol.MaxChunkSize)
+	first := true
+	for {
+		start := 0
+		if first {
+			if msgType == websocket.BinaryMessage {
+				buf[0] = 1
+			} else {
+				buf[0] = 0
+			}
+			start = 1
 		}
-		if err := s.SendRaw(protocol.FlagDAT|protocol.FlagMORE, buf[off:end]); err != nil {
+
+		n, err := io.ReadFull(reader, buf[start:])
+		if err != nil && err != io.EOF && err != io.ErrUnexpectedEOF {
 			return err
 		}
+		payload := buf[:start+n]
+		more := false
+		if err == nil {
+			if _, peekErr := reader.Peek(1); peekErr == nil {
+				more = true
+			} else if peekErr != io.EOF {
+				return peekErr
+			}
+		}
+		if !more {
+			return s.WriteDAT(payload)
+		}
+		if err := s.SendRaw(protocol.FlagDAT|protocol.FlagMORE, payload); err != nil {
+			return err
+		}
+		first = false
 	}
-	return s.WriteDAT(buf) // only reached for an empty message
+}
+
+func (h *WSHandler) remove(id uint32, want *wsStream) {
+	h.mu.Lock()
+	if h.streams[id] == want {
+		delete(h.streams, id)
+	}
+	h.mu.Unlock()
+}
+
+func (ws *wsStream) setConn(conn *websocket.Conn) bool {
+	ws.mu.Lock()
+	defer ws.mu.Unlock()
+	if ws.ctx.Err() != nil {
+		return false
+	}
+	ws.conn = conn
+	return true
+}
+
+func (ws *wsStream) writeFragment(payload []byte, more bool) error {
+	ws.writeMu.Lock()
+	defer ws.writeMu.Unlock()
+
+	ws.mu.Lock()
+	conn := ws.conn
+	ws.mu.Unlock()
+	if conn == nil {
+		return fmt.Errorf("websocket is not connected")
+	}
+
+	data := payload
+	if ws.writer == nil {
+		if len(payload) < 1 {
+			return fmt.Errorf("websocket fragment is missing its message type")
+		}
+		msgType := websocket.TextMessage
+		switch payload[0] {
+		case 0:
+		case 1:
+			msgType = websocket.BinaryMessage
+		default:
+			return fmt.Errorf("invalid websocket message type %d", payload[0])
+		}
+		writer, err := conn.NextWriter(msgType)
+		if err != nil {
+			return err
+		}
+		ws.writer = writer
+		data = payload[1:]
+	}
+	if err := bytestream.WriteFull(ws.writer, data); err != nil {
+		return err
+	}
+	if !more {
+		err := ws.writer.Close()
+		ws.writer = nil
+		return err
+	}
+	return nil
+}
+
+func (ws *wsStream) close() {
+	ws.cancel()
+	ws.mu.Lock()
+	conn := ws.conn
+	ws.mu.Unlock()
+	if conn != nil {
+		_ = conn.Close()
+	}
+	ws.writeMu.Lock()
+	if ws.writer != nil {
+		_ = ws.writer.Close()
+		ws.writer = nil
+	}
+	ws.writeMu.Unlock()
 }

--- a/internal/streamtype/websocket_test.go
+++ b/internal/streamtype/websocket_test.go
@@ -1,0 +1,177 @@
+package streamtype
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+	"github.com/richlegrand/bitbang/internal/protocol"
+)
+
+type wsTestStream struct {
+	id uint32
+
+	mu     sync.Mutex
+	frames []protocol.Frame
+}
+
+func (s *wsTestStream) ID() uint32          { return s.id }
+func (s *wsTestStream) ConnectPath() string { return "/" }
+func (s *wsTestStream) WriteSYN(payload []byte) error {
+	return s.capture(protocol.FlagSYN, payload)
+}
+func (s *wsTestStream) WriteDAT(payload []byte) error {
+	return s.capture(protocol.FlagDAT, payload)
+}
+func (s *wsTestStream) WriteFIN(payload []byte) error {
+	return s.capture(protocol.FlagFIN, payload)
+}
+func (s *wsTestStream) SendRaw(flags uint16, payload []byte) error {
+	return s.capture(flags, payload)
+}
+func (s *wsTestStream) BufferedAmount() uint64 { return 0 }
+
+func (s *wsTestStream) capture(flags uint16, payload []byte) error {
+	s.mu.Lock()
+	s.frames = append(s.frames, protocol.Frame{
+		StreamID: s.id,
+		Flags:    flags,
+		Payload:  append([]byte(nil), payload...),
+	})
+	s.mu.Unlock()
+	return nil
+}
+
+func (s *wsTestStream) snapshot() []protocol.Frame {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]protocol.Frame(nil), s.frames...)
+}
+
+func TestWriteWSReaderStreamsLargeMessageInOrder(t *testing.T) {
+	want := make([]byte, 1<<20+137)
+	for i := range want {
+		want[i] = byte(i * 31)
+	}
+	s := &wsTestStream{id: 11}
+	if err := writeWSReader(s, websocket.BinaryMessage, bytes.NewReader(want)); err != nil {
+		t.Fatalf("writeWSReader: %v", err)
+	}
+
+	frames := s.snapshot()
+	if len(frames) < 2 {
+		t.Fatalf("frame count = %d, want a fragmented message", len(frames))
+	}
+	var got bytes.Buffer
+	for i, frame := range frames {
+		if len(frame.Payload) > protocol.MaxChunkSize {
+			t.Fatalf("frame %d payload = %d bytes, max %d", i, len(frame.Payload), protocol.MaxChunkSize)
+		}
+		if i < len(frames)-1 && !frame.IsMORE() {
+			t.Fatalf("frame %d flags = %#x, want MORE", i, frame.Flags)
+		}
+		if i == len(frames)-1 && frame.IsMORE() {
+			t.Fatalf("final frame flags = %#x, want DAT", frame.Flags)
+		}
+		payload := frame.Payload
+		if i == 0 {
+			if len(payload) == 0 || payload[0] != 1 {
+				t.Fatalf("first payload = %v, want binary type byte", payload)
+			}
+			payload = payload[1:]
+		}
+		got.Write(payload)
+	}
+	if !bytes.Equal(got.Bytes(), want) {
+		t.Fatalf("reassembled %d bytes with matching=%v, want %d", got.Len(), bytes.Equal(got.Bytes(), want), len(want))
+	}
+}
+
+type fixedWSResolver struct {
+	target string
+}
+
+func (r fixedWSResolver) ResolveTarget(string) (string, string) {
+	return r.target, "/ws"
+}
+
+func TestWSHandlerForwardsLargeFragmentedMessage(t *testing.T) {
+	received := make(chan []byte, 1)
+	readErr := make(chan error, 1)
+	upgrader := websocket.Upgrader{CheckOrigin: func(*http.Request) bool { return true }}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			readErr <- err
+			return
+		}
+		defer conn.Close()
+		msgType, reader, err := conn.NextReader()
+		if err != nil {
+			readErr <- err
+			return
+		}
+		body, err := io.ReadAll(reader)
+		if err != nil {
+			readErr <- err
+			return
+		}
+		received <- append([]byte{byte(msgType)}, body...)
+	}))
+	defer server.Close()
+
+	h := NewWebSocket(fixedWSResolver{target: strings.TrimPrefix(server.URL, "http://")}, "", false)
+	s := newTCPTestStreamID(13)
+	open, _ := json.Marshal(map[string]string{"pathname": "/ws"})
+	if err := h.OnSYN(s, open, false); err != nil {
+		t.Fatalf("OnSYN: %v", err)
+	}
+	if ack := nextTCPFrame(t, s); !ack.IsSYN() || ack.IsFIN() {
+		t.Fatalf("ack flags = %#x, want SYN", ack.Flags)
+	}
+
+	want := make([]byte, 1<<20+333)
+	for i := range want {
+		want[i] = byte(i * 17)
+	}
+	firstLen := protocol.MaxChunkSize - 1
+	first := make([]byte, firstLen+1)
+	first[0] = 1
+	copy(first[1:], want[:firstLen])
+	if err := h.OnFragment(s, first, true); err != nil {
+		t.Fatalf("first fragment: %v", err)
+	}
+	for off := firstLen; off < len(want); {
+		end := off + protocol.MaxChunkSize
+		if end > len(want) {
+			end = len(want)
+		}
+		if err := h.OnFragment(s, want[off:end], end < len(want)); err != nil {
+			t.Fatalf("fragment at %d: %v", off, err)
+		}
+		off = end
+	}
+
+	select {
+	case got := <-received:
+		if got[0] != byte(websocket.BinaryMessage) || !bytes.Equal(got[1:], want) {
+			t.Fatalf("upstream got type=%d bytes=%d matching=%v", got[0], len(got)-1, bytes.Equal(got[1:], want))
+		}
+	case err := <-readErr:
+		t.Fatalf("upstream read: %v", err)
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for upstream WebSocket message")
+	}
+
+	_ = h.OnFIN(s, nil)
+}
+
+var _ FragmentHandler = (*WSHandler)(nil)
+var _ ResetHandler = (*WSHandler)(nil)


### PR DESCRIPTION
## Summary

- negotiate SWSP v4 with cumulative per-stream receive windows and stream-local resets
- dispatch each stream through an independent bounded queue so a slow handler cannot block the data-channel receive loop
- enforce sender credit in both listener and connector sessions, including directional FIN and teardown ordering
- stream HTTP, TCP, file, shell, and WebSocket traffic through bounded consumption paths
- preserve v2/v3 compatibility without emitting v4 controls

## Motivation

The shared receive loop previously invoked stream handlers inline. One slow consumer could therefore stall unrelated streams and shell traffic, while senders had no per-stream credit boundary.

SWSP v4 makes consumption explicit without changing the existing frame header. Receivers advertise cumulative byte limits on stream 0, senders wait only on the affected stream, and overflow or protocol errors reset that stream rather than the whole session.

Closes #14.

## Compatibility

The negotiated version is fixed by the initial connect/ready exchange. Missing versions still select v2, v3 peers retain their existing data path, and legacy receive queues remain locally bounded without sending unsupported controls.

## Testing

- `go test -count=1 ./...`
- `go test -race -count=1 ./...`
- `go vet ./...`
- real-Pion slow-stream acceptance test: 20 normal repetitions and 5 race-enabled repetitions
- Playwright E2E suite: 10 passed, including HTTP bodies, shell input, redirects, and WebSockets
- `git diff --check`

## Companion PR

- [richlegrand/bitbang-server#4](https://github.com/richlegrand/bitbang-server/pull/4) adds the matching browser and service-worker implementation.
